### PR TITLE
Support tree-authored virtual keyboards

### DIFF
--- a/demo.exs
+++ b/demo.exs
@@ -187,6 +187,10 @@ Process.put(:demo_swipe_up_count, 0)
 Process.put(:demo_swipe_down_count, 0)
 Process.put(:demo_swipe_left_count, 0)
 Process.put(:demo_swipe_right_count, 0)
+Process.put(:demo_soft_shift, false)
+Process.put(:demo_soft_popup, nil)
+Process.put(:demo_soft_hold_count, 0)
+Process.put(:demo_soft_last_action, "Tap the text input, then use the soft keys below.")
 
 clock_loop = fn loop ->
   send(demo_pid, {:clock_tick, clock_now.()})
@@ -1380,8 +1384,289 @@ defmodule Demo do
             text("Last action: #{key_listener_last_action}")
           )
         ])
+      ),
+      soft_keyboard_showcase_card()
+    ])
+  end
+
+  defp soft_keyboard_showcase_card() do
+    shift_active = Process.get(:demo_soft_shift, false)
+    popup = Process.get(:demo_soft_popup, nil)
+    hold_count = Process.get(:demo_soft_hold_count, 0)
+
+    last_action =
+      Process.get(:demo_soft_last_action, "Tap the text input, then use the soft keys below.")
+
+    popup_label =
+      case popup do
+        nil -> "none"
+        :a -> if(shift_active, do: "A popup", else: "a popup")
+        :e -> if(shift_active, do: "E popup", else: "e popup")
+        other -> inspect(other)
+      end
+
+    column([width(fill()), spacing(16)], [
+      section_title("Virtual keyboard"),
+      el(
+        [Font.size(12), Font.color(@dim_text)],
+        text(
+          "Each key below is a plain Emerge tree node using Event.virtual_key/1. Focus the text input for letters, or focus the key listener pad to watch Enter and arrows hit on_key_* handlers. Hold A or E to open alternates, and hold Backspace or arrows to repeat."
+        )
+      ),
+      el(
+        [
+          width(fill()),
+          padding(14),
+          spacing(10),
+          Background.color(color_rgb(46, 50, 72)),
+          Border.rounded(10)
+        ],
+        column([spacing(10)], [
+          wrapped_row([width(fill()), spacing_xy(8, 8)], [
+            soft_status_chip(
+              "Target",
+              soft_keyboard_target_label(),
+              color_rgb(70, 82, 112),
+              color_rgb(226, 234, 248)
+            ),
+            soft_status_chip(
+              "Shift",
+              if(shift_active, do: "On", else: "Off"),
+              if(shift_active, do: color_rgb(88, 118, 78), else: color_rgb(76, 74, 102)),
+              if(shift_active,
+                do: color_rgb(230, 246, 228),
+                else: color_rgb(224, 228, 242)
+              )
+            ),
+            soft_status_chip(
+              "Popup",
+              popup_label,
+              color_rgb(92, 76, 116),
+              color_rgb(244, 232, 248)
+            ),
+            soft_status_chip(
+              "Hold events",
+              Integer.to_string(hold_count),
+              color_rgb(74, 90, 124),
+              color_rgb(230, 238, 250)
+            )
+          ]),
+          wrapped_row([width(fill()), spacing_xy(8, 8)], [
+            soft_shift_toggle_key(shift_active),
+            soft_letter_key(:a, "a", "A", :a, shift_active, popup: popup),
+            soft_letter_key(:e, "e", "E", :e, shift_active, popup: popup),
+            soft_letter_key(:i, "i", "I", :i, shift_active),
+            soft_letter_key(:o, "o", "O", :o, shift_active),
+            soft_letter_key(:u, "u", "U", :u, shift_active),
+            soft_special_key_button(
+              "Backspace",
+              [tap: {:key, :backspace, []}, hold: :repeat],
+              id: :backspace,
+              width: px(124),
+              background: color_rgb(88, 68, 84),
+              hover_background: color_rgb(104, 82, 98),
+              border_color: color_rgb(168, 126, 152)
+            )
+          ]),
+          wrapped_row([width(fill()), spacing_xy(8, 8)], [
+            soft_special_key_button(
+              "Left",
+              [tap: {:key, :arrow_left, []}, hold: :repeat],
+              id: :arrow_left,
+              width: px(92),
+              background: color_rgb(62, 84, 108),
+              hover_background: color_rgb(76, 98, 124),
+              border_color: color_rgb(138, 170, 204)
+            ),
+            soft_special_key_button(
+              "Space",
+              [tap: {:text_and_key, " ", :space, []}],
+              id: :space,
+              width: px(220),
+              background: color_rgb(64, 72, 110),
+              hover_background: color_rgb(78, 86, 126),
+              border_color: color_rgb(138, 150, 206)
+            ),
+            soft_special_key_button(
+              "Right",
+              [tap: {:key, :arrow_right, []}, hold: :repeat],
+              id: :arrow_right,
+              width: px(92),
+              background: color_rgb(62, 84, 108),
+              hover_background: color_rgb(76, 98, 124),
+              border_color: color_rgb(138, 170, 204)
+            ),
+            soft_special_key_button(
+              "Enter",
+              [tap: {:key, :enter, []}],
+              id: :enter,
+              width: px(110),
+              background: color_rgb(72, 92, 78),
+              hover_background: color_rgb(86, 108, 92),
+              border_color: color_rgb(156, 196, 164)
+            )
+          ]),
+          el(
+            [Font.size(11), Font.color(color_rgb(230, 234, 246))],
+            text("Soft keyboard status: #{last_action}")
+          ),
+          el(
+            [Font.size(10), Font.color(@dim_text)],
+            text(
+              "Try this flow: focus the text field, tap Shift, tap A, hold E for alternates, then tap an accented popup key. Focus the keyboard listener pad to route Enter and arrows into on_key_* counters instead."
+            )
+          )
+        ])
       )
     ])
+  end
+
+  defp soft_keyboard_target_label() do
+    cond do
+      Process.get(:demo_input_focused, false) -> "Text input"
+      Process.get(:demo_key_listener_focused, false) -> "Keyboard listener pad"
+      Process.get(:demo_button_focused, false) -> "Run action button"
+      true -> "Nothing focused"
+    end
+  end
+
+  defp soft_status_chip(label, value, bg_color, text_color) do
+    el(
+      [padding_xy(10, 5), Background.color(bg_color), Border.rounded(999)],
+      el([Font.size(11), Font.color(text_color)], text("#{label}: #{value}"))
+    )
+  end
+
+  defp soft_shift_toggle_key(active?) do
+    bg = if active?, do: color_rgb(92, 118, 76), else: color_rgb(64, 68, 98)
+    hover_bg = if active?, do: color_rgb(106, 132, 88), else: color_rgb(76, 82, 112)
+    border_color = if active?, do: color_rgb(168, 204, 144), else: color_rgb(132, 140, 188)
+    label = if active?, do: "Shift On", else: "Shift"
+
+    el(
+      [
+        key(:soft_shift_toggle),
+        width(px(96)),
+        padding_xy(12, 10),
+        Background.color(bg),
+        Border.rounded(10),
+        Border.width(1),
+        Border.color(border_color),
+        Font.size(12),
+        Font.color(:white),
+        Event.on_click({self(), {:demo_event, :soft_keyboard, :toggle_shift}}),
+        Interactive.mouse_over([
+          Background.color(hover_bg),
+          Border.color(color_rgb(196, 208, 238))
+        ]),
+        Interactive.mouse_down([
+          Background.color(color_rgb(58, 62, 90)),
+          Transform.move_y(1)
+        ])
+      ],
+      text(label)
+    )
+  end
+
+  defp soft_letter_key(letter, lower, upper, key_name, shift_active, opts \\ []) do
+    popup_key = Keyword.get(opts, :popup)
+
+    popup_content =
+      if popup_key == letter, do: soft_alternate_popup(letter, shift_active), else: nil
+
+    spec =
+      [
+        tap:
+          if(shift_active,
+            do: {:text_and_key, upper, key_name, [:shift]},
+            else: {:text_and_key, lower, key_name, []}
+          )
+      ] ++
+        if letter in [:a, :e] do
+          [hold: {:event, {self(), {:demo_event, :soft_keyboard, {:show_alternates, letter}}}}]
+        else
+          []
+        end
+
+    soft_special_key_button(
+      if(shift_active, do: upper, else: lower),
+      spec,
+      id: {:letter, letter},
+      width: px(56),
+      popup: popup_content,
+      background: color_rgb(68, 74, 108),
+      hover_background: color_rgb(82, 88, 126),
+      border_color: color_rgb(142, 152, 206)
+    )
+  end
+
+  defp soft_special_key_button(label, spec, opts) do
+    background = Keyword.get(opts, :background, color_rgb(68, 74, 108))
+    hover_background = Keyword.get(opts, :hover_background, color_rgb(82, 88, 126))
+    border_color = Keyword.get(opts, :border_color, color_rgb(142, 152, 206))
+    popup = Keyword.get(opts, :popup)
+
+    attrs = [
+      key({:soft_key, Keyword.fetch!(opts, :id)}),
+      width(Keyword.get(opts, :width, px(64))),
+      padding_xy(12, 10),
+      Background.color(background),
+      Border.rounded(10),
+      Border.width(1),
+      Border.color(border_color),
+      Font.size(12),
+      Font.color(:white),
+      Event.virtual_key(spec),
+      Interactive.mouse_over([
+        Background.color(hover_background),
+        Border.color(color_rgb(196, 208, 238))
+      ]),
+      Interactive.mouse_down([
+        Background.color(color_rgb(58, 62, 90)),
+        Transform.move_y(1)
+      ])
+    ]
+
+    attrs = if popup, do: [Nearby.above(popup) | attrs], else: attrs
+
+    el(attrs, text(label))
+  end
+
+  defp soft_alternate_popup(:a, shift_active) do
+    labels = if shift_active, do: ["Á", "À", "Ä"], else: ["á", "à", "ä"]
+    soft_alternate_popup_panel(:a, labels)
+  end
+
+  defp soft_alternate_popup(:e, shift_active) do
+    labels = if shift_active, do: ["É", "È", "Ê"], else: ["é", "è", "ê"]
+    soft_alternate_popup_panel(:e, labels)
+  end
+
+  defp soft_alternate_popup_panel(owner, labels) do
+    el(
+      [
+        key({:soft_popup, owner}),
+        padding(8),
+        Background.color(color_rgb(38, 42, 64)),
+        Border.rounded(12),
+        Border.width(1),
+        Border.color(color_rgb(154, 168, 224))
+      ],
+      row(
+        [spacing(6)],
+        Enum.map(labels, fn label ->
+          soft_special_key_button(
+            label,
+            [tap: {:text, label}],
+            id: {:popup_key, owner, label},
+            width: px(48),
+            background: color_rgb(82, 72, 118),
+            hover_background: color_rgb(98, 84, 134),
+            border_color: color_rgb(188, 170, 236)
+          )
+        end)
+      )
+    )
   end
 
   defp page_layout() do
@@ -4469,15 +4754,65 @@ defmodule Demo do
   end
 
   defp process_event(
+         {:demo_event, :soft_keyboard, :toggle_shift},
+         _state,
+         {mouse_pos, event_log, size, scale, current_page, last_move_label, unstable_items}
+       ) do
+    previous = Process.get(:demo_soft_shift, false)
+    popup = Process.get(:demo_soft_popup, nil)
+    shift_active = !previous
+
+    Process.put(:demo_soft_shift, shift_active)
+    Process.put(:demo_soft_popup, nil)
+
+    entry = if shift_active, do: "Soft keyboard: shift on", else: "Soft keyboard: shift off"
+    Process.put(:demo_soft_last_action, entry)
+
+    new_log = Enum.take([entry | event_log], 20)
+    changed = previous != shift_active or popup != nil or new_log != event_log
+
+    {{mouse_pos, new_log, size, scale, current_page, last_move_label, unstable_items}, changed}
+  end
+
+  defp process_event(
+         {:demo_event, :soft_keyboard, {:show_alternates, key}},
+         _state,
+         {mouse_pos, event_log, size, scale, current_page, last_move_label, unstable_items}
+       )
+       when key in [:a, :e] do
+    previous_popup = Process.get(:demo_soft_popup, nil)
+    hold_count = Process.get(:demo_soft_hold_count, 0) + 1
+
+    Process.put(:demo_soft_popup, key)
+    Process.put(:demo_soft_hold_count, hold_count)
+
+    entry =
+      "Soft keyboard hold: #{String.upcase(Atom.to_string(key))} alternates (#{hold_count})"
+
+    Process.put(:demo_soft_last_action, entry)
+
+    new_log = Enum.take([entry | event_log], 20)
+    changed = previous_popup != key or new_log != event_log
+
+    {{mouse_pos, new_log, size, scale, current_page, last_move_label, unstable_items}, changed}
+  end
+
+  defp process_event(
          {:demo_event, :input_changed, value},
          _state,
          {mouse_pos, event_log, size, scale, current_page, last_move_label, unstable_items}
        )
        when is_binary(value) do
     previous = Process.get(:demo_input_value, "")
+    previous_popup = Process.get(:demo_soft_popup, nil)
     Process.put(:demo_input_value, value)
     Process.put(:demo_input_preedit, nil)
     Process.put(:demo_input_preedit_cursor, nil)
+    Process.put(:demo_soft_popup, nil)
+
+    if previous_popup != nil do
+      Process.put(:demo_soft_last_action, "Soft keyboard: alternate committed")
+    end
 
     changed_value = value != previous
 
@@ -4491,7 +4826,7 @@ defmodule Demo do
         event_log
       end
 
-    changed = changed_value or new_log != event_log
+    changed = changed_value or previous_popup != nil or new_log != event_log
 
     {{mouse_pos, new_log, size, scale, current_page, last_move_label, unstable_items}, changed}
   end
@@ -4503,12 +4838,14 @@ defmodule Demo do
        ) do
     previous = Process.get(:demo_input_focused, false)
     count = Process.get(:demo_input_focus_count, 0) + 1
+    previous_popup = Process.get(:demo_soft_popup, nil)
 
     Process.put(:demo_input_focused, true)
     Process.put(:demo_input_focus_count, count)
+    Process.put(:demo_soft_popup, nil)
 
     new_log = Enum.take(["Input focus (#{count})" | event_log], 20)
-    changed = !previous or new_log != event_log
+    changed = !previous or previous_popup != nil or new_log != event_log
 
     {{mouse_pos, new_log, size, scale, current_page, last_move_label, unstable_items}, changed}
   end
@@ -4520,12 +4857,14 @@ defmodule Demo do
        ) do
     previous = Process.get(:demo_input_focused, false)
     count = Process.get(:demo_input_blur_count, 0) + 1
+    previous_popup = Process.get(:demo_soft_popup, nil)
 
     Process.put(:demo_input_focused, false)
     Process.put(:demo_input_blur_count, count)
+    Process.put(:demo_soft_popup, nil)
 
     new_log = Enum.take(["Input blur (#{count})" | event_log], 20)
-    changed = previous or new_log != event_log
+    changed = previous or previous_popup != nil or new_log != event_log
 
     {{mouse_pos, new_log, size, scale, current_page, last_move_label, unstable_items}, changed}
   end
@@ -4551,12 +4890,14 @@ defmodule Demo do
        ) do
     previous = Process.get(:demo_button_focused, false)
     count = Process.get(:demo_button_focus_count, 0) + 1
+    previous_popup = Process.get(:demo_soft_popup, nil)
 
     Process.put(:demo_button_focused, true)
     Process.put(:demo_button_focus_count, count)
+    Process.put(:demo_soft_popup, nil)
 
     new_log = Enum.take(["Button focus (#{count})" | event_log], 20)
-    changed = !previous or new_log != event_log
+    changed = !previous or previous_popup != nil or new_log != event_log
 
     {{mouse_pos, new_log, size, scale, current_page, last_move_label, unstable_items}, changed}
   end
@@ -4568,12 +4909,14 @@ defmodule Demo do
        ) do
     previous = Process.get(:demo_button_focused, false)
     count = Process.get(:demo_button_blur_count, 0) + 1
+    previous_popup = Process.get(:demo_soft_popup, nil)
 
     Process.put(:demo_button_focused, false)
     Process.put(:demo_button_blur_count, count)
+    Process.put(:demo_soft_popup, nil)
 
     new_log = Enum.take(["Button blur (#{count})" | event_log], 20)
-    changed = previous or new_log != event_log
+    changed = previous or previous_popup != nil or new_log != event_log
 
     {{mouse_pos, new_log, size, scale, current_page, last_move_label, unstable_items}, changed}
   end
@@ -4585,12 +4928,14 @@ defmodule Demo do
        ) do
     previous = Process.get(:demo_key_listener_focused, false)
     count = Process.get(:demo_key_listener_focus_count, 0) + 1
+    previous_popup = Process.get(:demo_soft_popup, nil)
 
     Process.put(:demo_key_listener_focused, true)
     Process.put(:demo_key_listener_focus_count, count)
+    Process.put(:demo_soft_popup, nil)
 
     new_log = Enum.take(["Keyboard pad focus (#{count})" | event_log], 20)
-    changed = !previous or new_log != event_log
+    changed = !previous or previous_popup != nil or new_log != event_log
 
     {{mouse_pos, new_log, size, scale, current_page, last_move_label, unstable_items}, changed}
   end
@@ -4602,12 +4947,14 @@ defmodule Demo do
        ) do
     previous = Process.get(:demo_key_listener_focused, false)
     count = Process.get(:demo_key_listener_blur_count, 0) + 1
+    previous_popup = Process.get(:demo_soft_popup, nil)
 
     Process.put(:demo_key_listener_focused, false)
     Process.put(:demo_key_listener_blur_count, count)
+    Process.put(:demo_soft_popup, nil)
 
     new_log = Enum.take(["Keyboard pad blur (#{count})" | event_log], 20)
-    changed = previous or new_log != event_log
+    changed = previous or previous_popup != nil or new_log != event_log
 
     {{mouse_pos, new_log, size, scale, current_page, last_move_label, unstable_items}, changed}
   end

--- a/lib/emerge/engine/attr_codec.ex
+++ b/lib/emerge/engine/attr_codec.ex
@@ -73,7 +73,8 @@ defmodule Emerge.Engine.AttrCodec do
     on_swipe_up: 71,
     on_swipe_down: 72,
     on_swipe_left: 73,
-    on_swipe_right: 74
+    on_swipe_right: 74,
+    virtual_key: 75
   }
 
   @tag_type Map.new(@type_tag, fn {type, tag} -> {tag, type} end)
@@ -174,6 +175,7 @@ defmodule Emerge.Engine.AttrCodec do
   defp encode_value(:on_key_down, value), do: encode_key_bindings(value)
   defp encode_value(:on_key_up, value), do: encode_key_bindings(value)
   defp encode_value(:on_key_press, value), do: encode_key_bindings(value)
+  defp encode_value(:virtual_key, value), do: encode_virtual_key(value)
   defp encode_value(:on_change, _value), do: encode_bool(true)
   defp encode_value(:on_focus, _value), do: encode_bool(true)
   defp encode_value(:on_blur, _value), do: encode_bool(true)
@@ -240,6 +242,7 @@ defmodule Emerge.Engine.AttrCodec do
   defp decode_value(:on_key_down, rest), do: decode_key_bindings(rest)
   defp decode_value(:on_key_up, rest), do: decode_key_bindings(rest)
   defp decode_value(:on_key_press, rest), do: decode_key_bindings(rest)
+  defp decode_value(:virtual_key, rest), do: decode_virtual_key(rest)
   defp decode_value(:on_change, rest), do: decode_bool(rest)
   defp decode_value(:on_focus, rest), do: decode_bool(rest)
   defp decode_value(:on_blur, rest), do: decode_bool(rest)
@@ -359,6 +362,82 @@ defmodule Emerge.Engine.AttrCodec do
     }
 
     decode_key_bindings_payload(rest, [binding | acc], count - 1)
+  end
+
+  defp encode_virtual_key(value) do
+    %{tap: tap, hold: hold, hold_ms: hold_ms, repeat_ms: repeat_ms} =
+      Event.virtual_key_descriptor(value)
+
+    payload =
+      [
+        <<encode_virtual_key_tap_tag(tap)::unsigned-8,
+          encode_virtual_key_hold_tag(hold)::unsigned-8, hold_ms::unsigned-32,
+          repeat_ms::unsigned-32>>,
+        encode_virtual_key_tap_payload(tap)
+      ]
+      |> IO.iodata_to_binary()
+
+    <<byte_size(payload)::unsigned-32, payload::binary>>
+  end
+
+  defp decode_virtual_key(<<len::unsigned-32, rest::binary>>) do
+    <<payload::binary-size(len), rest::binary>> = rest
+    {value, <<>>} = decode_virtual_key_payload(payload)
+    {value, rest}
+  end
+
+  defp decode_virtual_key_payload(
+         <<tap_tag::unsigned-8, hold_tag::unsigned-8, hold_ms::unsigned-32,
+           repeat_ms::unsigned-32, rest::binary>>
+       ) do
+    {tap, rest} = decode_virtual_key_tap(tap_tag, rest)
+
+    {%{
+       tap: tap,
+       hold: decode_virtual_key_hold_tag(hold_tag),
+       hold_ms: hold_ms,
+       repeat_ms: repeat_ms
+     }, rest}
+  end
+
+  defp encode_virtual_key_tap_tag({:text, _text}), do: 0
+  defp encode_virtual_key_tap_tag({:key, _key, _mods}), do: 1
+  defp encode_virtual_key_tap_tag({:text_and_key, _text, _key, _mods}), do: 2
+
+  defp encode_virtual_key_hold_tag(:none), do: 0
+  defp encode_virtual_key_hold_tag(:repeat), do: 1
+  defp encode_virtual_key_hold_tag(:event), do: 2
+
+  defp decode_virtual_key_hold_tag(0), do: :none
+  defp decode_virtual_key_hold_tag(1), do: :repeat
+  defp decode_virtual_key_hold_tag(2), do: :event
+
+  defp encode_virtual_key_tap_payload({:text, text}), do: encode_string(text)
+
+  defp encode_virtual_key_tap_payload({:key, key, mods}) do
+    [encode_atom(key), <<encode_key_modifiers(mods)::unsigned-8>>]
+  end
+
+  defp encode_virtual_key_tap_payload({:text_and_key, text, key, mods}) do
+    [encode_string(text), encode_atom(key), <<encode_key_modifiers(mods)::unsigned-8>>]
+  end
+
+  defp decode_virtual_key_tap(0, rest) do
+    {text, rest} = decode_string(rest)
+    {{:text, text}, rest}
+  end
+
+  defp decode_virtual_key_tap(1, rest) do
+    {key, rest} = decode_atom(rest)
+    <<mods_mask::unsigned-8, rest::binary>> = rest
+    {{:key, key, decode_key_modifiers(mods_mask)}, rest}
+  end
+
+  defp decode_virtual_key_tap(2, rest) do
+    {text, rest} = decode_string(rest)
+    {key, rest} = decode_atom(rest)
+    <<mods_mask::unsigned-8, rest::binary>> = rest
+    {{:text_and_key, text, key, decode_key_modifiers(mods_mask)}, rest}
   end
 
   defp encode_bool(true), do: <<1>>

--- a/lib/emerge/engine/diff_state.ex
+++ b/lib/emerge/engine/diff_state.ex
@@ -112,6 +112,7 @@ defmodule Emerge.Engine.DiffState do
     |> register_event(element, :on_change, :change)
     |> register_event(element, :on_focus, :focus)
     |> register_event(element, :on_blur, :blur)
+    |> register_virtual_key_hold_event(element)
     |> register_key_events(element, :on_key_down, :key_down)
     |> register_key_events(element, :on_key_up, :key_up)
     |> register_key_events(element, :on_key_press, :key_press)
@@ -164,4 +165,18 @@ defmodule Emerge.Engine.DiffState do
   end
 
   defp register_key_event(acc, _element, _event_type, _binding), do: acc
+
+  defp register_virtual_key_hold_event(acc, element) do
+    case Map.get(element.attrs, :virtual_key) do
+      %{hold: {:event, {pid, msg}}} when is_pid(pid) ->
+        id_bin = :erlang.term_to_binary(element.id)
+
+        Map.update(acc, id_bin, %{virtual_key_hold: {pid, msg}}, fn events ->
+          Map.put(events, :virtual_key_hold, {pid, msg})
+        end)
+
+      _ ->
+        acc
+    end
+  end
 end

--- a/lib/emerge/ui/event.ex
+++ b/lib/emerge/ui/event.ex
@@ -141,9 +141,31 @@ defmodule Emerge.UI.Event do
           required(:route) => binary()
         }
 
+  @type virtual_key_tap ::
+          {:text, binary()}
+          | {:key, key_name(), [key_modifier()]}
+          | {:text_and_key, binary(), key_name(), [key_modifier()]}
+
+  @type virtual_key_hold :: nil | :repeat | {:event, payload()}
+
+  @type virtual_key_spec :: %{
+          required(:tap) => virtual_key_tap(),
+          optional(:hold) => virtual_key_hold(),
+          optional(:hold_ms) => non_neg_integer(),
+          optional(:repeat_ms) => pos_integer()
+        }
+
+  @type virtual_key_descriptor :: %{
+          required(:tap) => virtual_key_tap(),
+          required(:hold) => :none | :repeat | :event,
+          required(:hold_ms) => non_neg_integer(),
+          required(:repeat_ms) => pos_integer()
+        }
+
   @type key_down_attr :: {:on_key_down, key_binding()}
   @type key_up_attr :: {:on_key_up, key_binding()}
   @type key_press_attr :: {:on_key_press, key_binding()}
+  @type virtual_key_attr :: {:virtual_key, virtual_key_spec()}
 
   @type t ::
           click_attr()
@@ -163,8 +185,11 @@ defmodule Emerge.UI.Event do
           | key_down_attr()
           | key_up_attr()
           | key_press_attr()
+          | virtual_key_attr()
 
   @key_modifiers [:shift, :ctrl, :alt, :meta]
+  @default_virtual_key_hold_ms 350
+  @default_virtual_key_repeat_ms 40
 
   @key_names [
     :a,
@@ -366,6 +391,12 @@ defmodule Emerge.UI.Event do
 
   def on_key_press(matcher, message), do: on_key_press(matcher, {self(), message})
 
+  @doc "Register soft-key behavior for a plain tree element"
+  @spec virtual_key(virtual_key_spec() | keyword()) :: virtual_key_attr()
+  def virtual_key(spec) do
+    {:virtual_key, normalize_virtual_key!(spec)}
+  end
+
   @doc false
   @spec normalize_key_listener_bindings!(:on_key_down | :on_key_up | :on_key_press, term()) ::
           [key_binding()]
@@ -382,6 +413,57 @@ defmodule Emerge.UI.Event do
         raise ArgumentError,
               "#{inspect(attr)} expects a key binding map or list of key binding maps, got: #{inspect(other)}"
     end
+  end
+
+  @doc false
+  @spec normalize_virtual_key!(virtual_key_spec() | keyword()) :: virtual_key_spec()
+  def normalize_virtual_key!(value) do
+    spec = normalize_virtual_key_spec_map!(value)
+    ensure_only_keys!(:virtual_key, spec, [:tap, :hold, :hold_ms, :repeat_ms])
+
+    tap =
+      case Map.fetch(spec, :tap) do
+        {:ok, tap} -> normalize_virtual_key_tap!(tap)
+        :error -> missing_virtual_key_tap!()
+      end
+
+    hold =
+      spec
+      |> Map.get(:hold, nil)
+      |> normalize_virtual_key_hold!()
+
+    hold_ms =
+      normalize_virtual_key_hold_ms!(Map.get(spec, :hold_ms, @default_virtual_key_hold_ms))
+
+    repeat_ms =
+      normalize_virtual_key_repeat_ms!(Map.get(spec, :repeat_ms, @default_virtual_key_repeat_ms))
+
+    %{tap: tap, hold: hold, hold_ms: hold_ms, repeat_ms: repeat_ms}
+  end
+
+  @doc false
+  @spec virtual_key_descriptor(virtual_key_spec()) :: virtual_key_descriptor()
+  def virtual_key_descriptor(spec) do
+    spec = normalize_virtual_key_spec_map!(spec)
+    ensure_only_keys!(:virtual_key, spec, [:tap, :hold, :hold_ms, :repeat_ms])
+
+    tap =
+      spec
+      |> Map.fetch!(:tap)
+      |> normalize_virtual_key_tap!()
+
+    hold =
+      spec
+      |> Map.get(:hold, nil)
+      |> normalize_virtual_key_hold_descriptor!()
+
+    hold_ms =
+      normalize_virtual_key_hold_ms!(Map.get(spec, :hold_ms, @default_virtual_key_hold_ms))
+
+    repeat_ms =
+      normalize_virtual_key_repeat_ms!(Map.get(spec, :repeat_ms, @default_virtual_key_repeat_ms))
+
+    %{tap: tap, hold: hold, hold_ms: hold_ms, repeat_ms: repeat_ms}
   end
 
   @doc false
@@ -406,6 +488,80 @@ defmodule Emerge.UI.Event do
           key_binding_descriptor()
   def key_binding_descriptor(%{key: key, mods: mods, match: match, route: route}) do
     %{key: key, mods: mods, match: match, route: route}
+  end
+
+  defp normalize_virtual_key_spec_map!(value) when is_map(value), do: value
+
+  defp normalize_virtual_key_spec_map!(value) when is_list(value) do
+    if Keyword.keyword?(value) do
+      Map.new(value)
+    else
+      raise ArgumentError,
+            "virtual_key expects a map or keyword spec, got: #{inspect(value)}"
+    end
+  end
+
+  defp normalize_virtual_key_spec_map!(value) do
+    raise ArgumentError,
+          "virtual_key expects a map or keyword spec, got: #{inspect(value)}"
+  end
+
+  defp normalize_virtual_key_tap!({:text, text}) when is_binary(text), do: {:text, text}
+
+  defp normalize_virtual_key_tap!({:key, key, mods}) do
+    {:key, normalize_key_name!(key, :virtual_key), normalize_key_modifiers!(mods, :virtual_key)}
+  end
+
+  defp normalize_virtual_key_tap!({:text_and_key, text, key, mods}) when is_binary(text) do
+    {:text_and_key, text, normalize_key_name!(key, :virtual_key),
+     normalize_key_modifiers!(mods, :virtual_key)}
+  end
+
+  defp normalize_virtual_key_tap!(other) do
+    raise ArgumentError,
+          "virtual_key expects :tap to be {:text, binary}, {:key, key, mods}, or {:text_and_key, text, key, mods}, got: #{inspect(other)}"
+  end
+
+  defp normalize_virtual_key_hold!(nil), do: nil
+  defp normalize_virtual_key_hold!(:repeat), do: :repeat
+
+  defp normalize_virtual_key_hold!({:event, payload}) do
+    {:event, normalize_event_payload!(payload, :virtual_key)}
+  end
+
+  defp normalize_virtual_key_hold!(other) do
+    raise ArgumentError,
+          "virtual_key expects :hold to be nil, :repeat, or {:event, {pid, message}}, got: #{inspect(other)}"
+  end
+
+  defp normalize_virtual_key_hold_descriptor!(nil), do: :none
+  defp normalize_virtual_key_hold_descriptor!(:none), do: :none
+  defp normalize_virtual_key_hold_descriptor!(:repeat), do: :repeat
+
+  defp normalize_virtual_key_hold_descriptor!({:event, payload}) do
+    _ = normalize_event_payload!(payload, :virtual_key)
+    :event
+  end
+
+  defp normalize_virtual_key_hold_descriptor!(:event), do: :event
+
+  defp normalize_virtual_key_hold_descriptor!(other) do
+    raise ArgumentError,
+          "virtual_key expects :hold to be nil, :none, :repeat, :event, or {:event, {pid, message}}, got: #{inspect(other)}"
+  end
+
+  defp normalize_virtual_key_hold_ms!(value) when is_integer(value) and value >= 0, do: value
+
+  defp normalize_virtual_key_hold_ms!(value) do
+    raise ArgumentError,
+          "virtual_key expects :hold_ms to be a non-negative integer, got: #{inspect(value)}"
+  end
+
+  defp normalize_virtual_key_repeat_ms!(value) when is_integer(value) and value > 0, do: value
+
+  defp normalize_virtual_key_repeat_ms!(value) do
+    raise ArgumentError,
+          "virtual_key expects :repeat_ms to be a positive integer, got: #{inspect(value)}"
   end
 
   defp build_key_binding!(event_type, matcher, payload) do
@@ -553,5 +709,9 @@ defmodule Emerge.UI.Event do
   defp missing_key_matcher_key!(event_type) do
     raise ArgumentError,
           "#{inspect(event_type)} keyword matcher expects a :key entry"
+  end
+
+  defp missing_virtual_key_tap! do
+    raise ArgumentError, "virtual_key expects a :tap entry"
   end
 end

--- a/lib/emerge/ui/internal/validation.ex
+++ b/lib/emerge/ui/internal/validation.ex
@@ -69,6 +69,7 @@ defmodule Emerge.UI.Internal.Validation do
                       :on_key_down,
                       :on_key_up,
                       :on_key_press,
+                      :virtual_key,
                       :above,
                       :below,
                       :on_left,
@@ -97,7 +98,8 @@ defmodule Emerge.UI.Internal.Validation do
     warn_overrides = Keyword.get(opts, :warn_overrides, true)
     extra_public_attr_keys = MapSet.new(Keyword.get(opts, :extra_public_attr_keys, []))
 
-    Enum.reduce(attrs, %{}, fn attr, acc ->
+    attrs
+    |> Enum.reduce(%{}, fn attr, acc ->
       {key, value} = validate_attr_entry!(attrs_owner, attr, extra_public_attr_keys)
 
       case key do
@@ -108,6 +110,7 @@ defmodule Emerge.UI.Internal.Validation do
           put_attr(acc, key, value, warn_overrides)
       end
     end)
+    |> validate_attr_conflicts!(attrs_owner)
   end
 
   @spec parse_state_style_attrs(attrs_list(), state_style_key()) :: attrs_map()
@@ -251,6 +254,9 @@ defmodule Emerge.UI.Internal.Validation do
       key in [:on_key_down, :on_key_up, :on_key_press] ->
         {key, Event.normalize_key_listener_bindings!(key, value)}
 
+      key == :virtual_key ->
+        {key, Event.normalize_virtual_key!(value)}
+
       MapSet.member?(@public_attr_keys, key) or MapSet.member?(extra_public_attr_keys, key) ->
         validate_public_attr_value!(attrs_owner, key, value)
         {key, value}
@@ -270,6 +276,7 @@ defmodule Emerge.UI.Internal.Validation do
   defp validate_public_attr_value!(_attrs_owner, :animate, _value), do: :ok
   defp validate_public_attr_value!(_attrs_owner, :animate_enter, _value), do: :ok
   defp validate_public_attr_value!(_attrs_owner, :animate_exit, _value), do: :ok
+  defp validate_public_attr_value!(_attrs_owner, :virtual_key, _value), do: :ok
 
   defp validate_public_attr_value!(attrs_owner, :width, value),
     do: validate_length!(attrs_owner, :width, value)
@@ -516,5 +523,15 @@ defmodule Emerge.UI.Internal.Validation do
   defp validate_event_payload!(attrs_owner, key, value) do
     raise ArgumentError,
           "#{attrs_owner} expects #{inspect(key)} to be a {pid, message} tuple, got: #{inspect(value)}"
+  end
+
+  defp validate_attr_conflicts!(attrs, attrs_owner) do
+    if Map.has_key?(attrs, :virtual_key) and
+         (Map.has_key?(attrs, :on_click) or Map.has_key?(attrs, :on_press)) do
+      raise ArgumentError,
+            "#{attrs_owner} does not allow :virtual_key together with :on_click or :on_press"
+    end
+
+    attrs
   end
 end

--- a/native/emerge_skia/src/events.rs
+++ b/native/emerge_skia/src/events.rs
@@ -70,6 +70,7 @@ pub enum ElementEventKind {
     KeyDown,
     KeyUp,
     KeyPress,
+    VirtualKeyHold,
     MouseDown,
     MouseUp,
     MouseEnter,
@@ -654,6 +655,7 @@ rustler::atoms! {
     key_down,
     key_up,
     key_press,
+    virtual_key_hold,
     change,
     focus,
     blur,
@@ -701,6 +703,10 @@ pub(crate) fn key_up_atom() -> Atom {
 
 pub(crate) fn key_press_atom() -> Atom {
     key_press()
+}
+
+pub(crate) fn virtual_key_hold_atom() -> Atom {
+    virtual_key_hold()
 }
 
 pub(crate) fn change_atom() -> Atom {

--- a/native/emerge_skia/src/events/registry_builder.rs
+++ b/native/emerge_skia/src/events/registry_builder.rs
@@ -47,7 +47,9 @@ use crate::input::{
     SCROLL_LINE_PIXELS,
 };
 use crate::keys::CanonicalKey;
-use crate::tree::attrs::{KeyBindingMatch, KeyBindingSpec};
+use crate::tree::attrs::{
+    KeyBindingMatch, KeyBindingSpec, VirtualKeyHoldMode, VirtualKeyTapAction,
+};
 use crate::tree::element::{
     Element, ElementId, ElementKind, ElementTree, NearbySlot, RetainedChildMode, RetainedPaintPhase,
 };
@@ -229,6 +231,24 @@ pub struct ClickPressTracker {
     pub matcher_kind: ListenerMatcherKind,
     pub emit_click: bool,
     pub emit_press_pointer: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VirtualKeyPhase {
+    Armed,
+    Repeating,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct VirtualKeyTracker {
+    pub element_id: ElementId,
+    pub region: PointerRegion,
+    pub tap: VirtualKeyTapAction,
+    pub hold: VirtualKeyHoldMode,
+    pub hold_ms: u32,
+    pub repeat_ms: u32,
+    pub phase: VirtualKeyPhase,
 }
 
 /// Pointer-sensitive region backed by element interaction geometry.
@@ -459,6 +479,7 @@ pub struct SwipeTracker {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct RuntimeOverlayState {
     pub click_press: Option<ClickPressTracker>,
+    pub virtual_key: Option<VirtualKeyTracker>,
     pub key_presses: Vec<KeyPressTracker>,
     pub drag: DragTrackerState,
     pub swipe: Option<SwipeTracker>,
@@ -479,6 +500,12 @@ fn emit_runtime_overlay_listeners(
         base,
         &runtime.drag,
     ));
+    out.emit_opt(
+        runtime
+            .virtual_key
+            .as_ref()
+            .map(runtime_virtual_key_release_listener),
+    );
     out.emit_all(runtime_key_press_release_listeners(
         base,
         &runtime.key_presses,
@@ -501,9 +528,21 @@ fn emit_runtime_overlay_listeners(
     ));
     out.emit_opt(
         runtime
+            .virtual_key
+            .as_ref()
+            .map(runtime_virtual_key_release_anywhere_clear_listener),
+    );
+    out.emit_opt(
+        runtime
             .click_press
             .as_ref()
             .and_then(|tracker| runtime_click_press_release_anywhere_clear_listener(base, tracker)),
+    );
+    out.emit_opt(
+        runtime
+            .virtual_key
+            .as_ref()
+            .and_then(runtime_virtual_key_leave_cancel_listener),
     );
     out.emit_opt(runtime_drag_active_scroll_move_listener(
         base,
@@ -514,6 +553,12 @@ fn emit_runtime_overlay_listeners(
         &runtime.drag,
     ));
     out.emit_opt(runtime_drag_window_blur_clear_listener(base, &runtime.drag));
+    out.emit_opt(
+        runtime
+            .virtual_key
+            .as_ref()
+            .map(runtime_virtual_key_window_blur_clear_listener),
+    );
     out.emit_opt(runtime_key_press_window_blur_clear_listener(
         &runtime.key_presses,
     ));
@@ -553,6 +598,12 @@ fn emit_runtime_overlay_listeners(
         base,
         &runtime.drag,
     ));
+    out.emit_opt(
+        runtime
+            .virtual_key
+            .as_ref()
+            .map(runtime_virtual_key_window_leave_clear_listener),
+    );
     out.emit_opt(
         runtime
             .swipe
@@ -949,6 +1000,121 @@ fn runtime_click_press_window_leave_clear_listener(
             ],
         },
     })
+}
+
+pub(crate) fn synthetic_input_sequence_for_virtual_key_tap(
+    tap: &VirtualKeyTapAction,
+) -> Vec<InputEvent> {
+    match tap {
+        VirtualKeyTapAction::Text(text) => vec![InputEvent::TextCommit {
+            text: text.clone(),
+            mods: 0,
+        }],
+        VirtualKeyTapAction::Key { key, mods } => vec![
+            InputEvent::Key {
+                key: *key,
+                action: ACTION_PRESS,
+                mods: *mods,
+            },
+            InputEvent::Key {
+                key: *key,
+                action: ACTION_RELEASE,
+                mods: *mods,
+            },
+        ],
+        VirtualKeyTapAction::TextAndKey { text, key, mods } => vec![
+            InputEvent::Key {
+                key: *key,
+                action: ACTION_PRESS,
+                mods: *mods,
+            },
+            InputEvent::TextCommit {
+                text: text.clone(),
+                mods: *mods,
+            },
+            InputEvent::Key {
+                key: *key,
+                action: ACTION_RELEASE,
+                mods: *mods,
+            },
+        ],
+    }
+}
+
+fn runtime_virtual_key_release_listener(tracker: &VirtualKeyTracker) -> Listener {
+    let mut actions = Vec::new();
+
+    if tracker.phase == VirtualKeyPhase::Armed {
+        actions.push(ListenerAction::SyntheticInput(
+            synthetic_input_sequence_for_virtual_key_tap(&tracker.tap),
+        ));
+    }
+
+    actions.push(ListenerAction::RuntimeChange(
+        RuntimeChange::ClearVirtualKeyTracker,
+    ));
+
+    Listener {
+        element_id: Some(tracker.element_id.clone()),
+        matcher: ListenerMatcher::CursorButtonLeftReleaseInside {
+            region: tracker.region.clone(),
+        },
+        compute: ListenerCompute::DispatchBaseThenStatic { actions },
+    }
+}
+
+fn runtime_virtual_key_release_anywhere_clear_listener(tracker: &VirtualKeyTracker) -> Listener {
+    Listener {
+        element_id: Some(tracker.element_id.clone()),
+        matcher: ListenerMatcher::CursorButtonLeftReleaseAnywhere,
+        compute: ListenerCompute::Static {
+            actions: vec![ListenerAction::RuntimeChange(
+                RuntimeChange::ClearVirtualKeyTracker,
+            )],
+        },
+    }
+}
+
+fn runtime_virtual_key_leave_cancel_listener(tracker: &VirtualKeyTracker) -> Option<Listener> {
+    matches!(
+        tracker.phase,
+        VirtualKeyPhase::Armed | VirtualKeyPhase::Repeating
+    )
+    .then(|| Listener {
+        element_id: Some(tracker.element_id.clone()),
+        matcher: ListenerMatcher::CursorLocationLeaveBoundary {
+            region: tracker.region.clone(),
+        },
+        compute: ListenerCompute::DispatchBaseThenStatic {
+            actions: vec![ListenerAction::RuntimeChange(
+                RuntimeChange::CancelVirtualKeyTracker,
+            )],
+        },
+    })
+}
+
+fn runtime_virtual_key_window_blur_clear_listener(tracker: &VirtualKeyTracker) -> Listener {
+    Listener {
+        element_id: Some(tracker.element_id.clone()),
+        matcher: ListenerMatcher::WindowBlurred,
+        compute: ListenerCompute::DispatchBaseThenStatic {
+            actions: vec![ListenerAction::RuntimeChange(
+                RuntimeChange::ClearVirtualKeyTracker,
+            )],
+        },
+    }
+}
+
+fn runtime_virtual_key_window_leave_clear_listener(tracker: &VirtualKeyTracker) -> Listener {
+    Listener {
+        element_id: Some(tracker.element_id.clone()),
+        matcher: ListenerMatcher::WindowCursorLeft,
+        compute: ListenerCompute::DispatchBaseThenStatic {
+            actions: vec![ListenerAction::RuntimeChange(
+                RuntimeChange::ClearVirtualKeyTracker,
+            )],
+        },
+    }
 }
 
 fn runtime_key_press_release_listeners(
@@ -1754,6 +1920,8 @@ pub enum ListenerAction {
     TreeMsg(TreeMsg),
     /// Event-runtime transient mutation.
     RuntimeChange(RuntimeChange),
+    /// Synthetic raw input re-injected through the normal runtime pipeline.
+    SyntheticInput(Vec<InputEvent>),
     /// Request a cursor icon update from the event runtime.
     SetCursor(CursorIcon),
     /// Event forwarded to Elixir-side consumers.
@@ -1809,6 +1977,8 @@ pub enum RuntimeChange {
         emit_click: bool,
         emit_press_pointer: bool,
     },
+    /// Begin virtual-key press tracking.
+    StartVirtualKeyTracker { tracker: VirtualKeyTracker },
     /// Begin completed key-press followup tracking.
     StartKeyPressTracker { tracker: KeyPressTracker },
     /// Begin drag threshold tracking.
@@ -1842,6 +2012,10 @@ pub enum RuntimeChange {
     StartSwipeTracker { tracker: SwipeTracker },
     /// Drop swipe followup tracking.
     ClearSwipeTracker,
+    /// Cancel the active virtual-key gesture until release.
+    CancelVirtualKeyTracker,
+    /// Drop virtual-key tracking entirely.
+    ClearVirtualKeyTracker,
     /// Drop completed key-press tracking for one key.
     ClearKeyPressTrackersForKey { key: CanonicalKey },
     /// Drop all completed key-press tracking.
@@ -1871,6 +2045,7 @@ impl RuntimeChange {
         matches!(
             self,
             RuntimeChange::StartClickPressTracker { .. }
+                | RuntimeChange::StartVirtualKeyTracker { .. }
                 | RuntimeChange::StartKeyPressTracker { .. }
                 | RuntimeChange::StartDragTracker { .. }
                 | RuntimeChange::PromoteDragTracker { .. }
@@ -1880,6 +2055,8 @@ impl RuntimeChange {
                 | RuntimeChange::ClearClickPressTracker
                 | RuntimeChange::StartSwipeTracker { .. }
                 | RuntimeChange::ClearSwipeTracker
+                | RuntimeChange::CancelVirtualKeyTracker
+                | RuntimeChange::ClearVirtualKeyTracker
                 | RuntimeChange::ClearKeyPressTrackersForKey { .. }
                 | RuntimeChange::ClearKeyPressTrackers
                 | RuntimeChange::StartScrollbarDrag { .. }
@@ -3913,6 +4090,7 @@ fn cursor_icon_for_element(element: &Element) -> Option<CursorIcon> {
     } else if element.attrs.on_click.unwrap_or(false)
         || element.attrs.on_press.unwrap_or(false)
         || has_swipe_listener(element)
+        || element.attrs.virtual_key.is_some()
     {
         Some(CursorIcon::Pointer)
     } else {
@@ -3955,13 +4133,14 @@ fn owns_steady_cursor_inside(element: &Element, has_scrollbar_hover: bool) -> bo
 }
 
 fn is_focusable(element: &Element) -> bool {
-    element.kind == ElementKind::TextInput
-        || element.attrs.on_press.unwrap_or(false)
-        || element.attrs.on_focus.unwrap_or(false)
-        || element.attrs.on_blur.unwrap_or(false)
-        || element.attrs.on_key_down.is_some()
-        || element.attrs.on_key_up.is_some()
-        || element.attrs.on_key_press.is_some()
+    element.attrs.virtual_key.is_none()
+        && (element.kind == ElementKind::TextInput
+            || element.attrs.on_press.unwrap_or(false)
+            || element.attrs.on_focus.unwrap_or(false)
+            || element.attrs.on_blur.unwrap_or(false)
+            || element.attrs.on_key_down.is_some()
+            || element.attrs.on_key_up.is_some()
+            || element.attrs.on_key_press.is_some())
 }
 
 fn padding_sides(element: &Element) -> (f32, f32, f32, f32) {
@@ -4848,11 +5027,14 @@ fn slot_primary_left_press(
     focus_meta: Option<&ElementFocusMeta>,
 ) -> Option<Listener> {
     let region = pointer_region_for_element(state?)?;
-    let matcher = ListenerMatcher::CursorButtonLeftPressInside { region };
+    let matcher = ListenerMatcher::CursorButtonLeftPressInside {
+        region: region.clone(),
+    };
     let matcher_kind = matcher.kind();
     let actions: Vec<_> = mouse_events::left_press_actions(element)
         .into_iter()
         .chain(mouse_down_style::left_press_actions(element))
+        .chain(virtual_key::left_press_actions(element, &region))
         .chain(
             focus_meta
                 .filter(|focus_meta| is_focusable(element) && !focus_meta.is_currently_focused)
@@ -5532,6 +5714,37 @@ mod mouse_down_style {
 }
 
 /// Click/press tracker bootstrap contributors (`on_click`, pointer `on_press`, swipe, drag-scrollable containers).
+mod virtual_key {
+    use super::*;
+
+    pub(super) fn left_press_actions(
+        element: &Element,
+        region: &PointerRegion,
+    ) -> Vec<ListenerAction> {
+        element
+            .attrs
+            .virtual_key
+            .as_ref()
+            .map(|spec| {
+                vec![ListenerAction::RuntimeChange(
+                    RuntimeChange::StartVirtualKeyTracker {
+                        tracker: VirtualKeyTracker {
+                            element_id: element.id.clone(),
+                            region: region.clone(),
+                            tap: spec.tap.clone(),
+                            hold: spec.hold,
+                            hold_ms: spec.hold_ms,
+                            repeat_ms: spec.repeat_ms,
+                            phase: VirtualKeyPhase::Armed,
+                        },
+                    },
+                )]
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// Click/press tracker bootstrap contributors (`on_click`, pointer `on_press`, swipe, drag-scrollable containers).
 mod click_press_tracker {
     use super::*;
 
@@ -5660,7 +5873,7 @@ mod tests {
     use crate::tree::attrs::TextAlign;
     use crate::tree::attrs::{
         AlignX, AlignY, Attrs, KeyBindingMatch, KeyBindingSpec, Length, MouseOverAttrs,
-        ScrollbarHoverAxis,
+        ScrollbarHoverAxis, VirtualKeyHoldMode, VirtualKeySpec, VirtualKeyTapAction,
     };
     use crate::tree::element::{Element, ElementId, ElementKind, Frame, NearbySlot};
     use crate::tree::geometry::{clamp_radii, ClipShape, CornerRadii, Rect, ShapeBounds};
@@ -5678,7 +5891,7 @@ mod tests {
         ListenerCompute, ListenerComputeCtx, ListenerInput, ListenerMatcher, ListenerMatcherKind,
         NoopListenerComputeCtx, PointerRegion, RuntimeChange, RuntimeOverlayState, ScrollDirection,
         ScrollbarDragTracker, ScrollbarHitArea, ScrollbarPressSpec, SwipeHandlers, SwipeTracker,
-        TextDragTracker,
+        TextDragTracker, VirtualKeyPhase, VirtualKeyTracker,
     };
     use crate::events::{CursorIcon, ElementEventKind, TextInputState};
 
@@ -7338,6 +7551,7 @@ mod tests {
                 emit_click: true,
                 emit_press_pointer: false,
             }),
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Candidate {
                 element_id: ElementId::from_term_bytes(vec![30]),
@@ -7393,6 +7607,7 @@ mod tests {
                 emit_click: true,
                 emit_press_pointer: false,
             }),
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Inactive,
             swipe: None,
@@ -7446,6 +7661,7 @@ mod tests {
                 emit_click: true,
                 emit_press_pointer: false,
             }),
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Inactive,
             swipe: None,
@@ -7490,6 +7706,7 @@ mod tests {
                 emit_click: false,
                 emit_press_pointer: true,
             }),
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Inactive,
             swipe: None,
@@ -7542,6 +7759,7 @@ mod tests {
                 emit_click: true,
                 emit_press_pointer: false,
             }),
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Active {
                 element_id: ElementId::from_term_bytes(vec![29]),
@@ -7595,6 +7813,7 @@ mod tests {
                 emit_click: true,
                 emit_press_pointer: false,
             }),
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Candidate {
                 element_id: ElementId::from_term_bytes(vec![31]),
@@ -7645,6 +7864,7 @@ mod tests {
                 emit_click: true,
                 emit_press_pointer: false,
             }),
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Candidate {
                 element_id: ElementId::from_term_bytes(vec![31]),
@@ -7746,6 +7966,7 @@ mod tests {
 
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Candidate {
                 element_id: ElementId::from_term_bytes(vec![72]),
@@ -7798,6 +8019,7 @@ mod tests {
 
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Candidate {
                 element_id: ElementId::from_term_bytes(vec![75]),
@@ -7884,6 +8106,7 @@ mod tests {
         let base = registry_for_elements(&[parent, child]);
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Candidate {
                 element_id: ElementId::from_term_bytes(vec![77]),
@@ -7964,6 +8187,7 @@ mod tests {
         let base = registry_for_elements(&[parent, child]);
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Candidate {
                 element_id: ElementId::from_term_bytes(vec![79]),
@@ -8019,6 +8243,7 @@ mod tests {
 
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Inactive,
             swipe: Some(SwipeTracker {
@@ -8080,6 +8305,7 @@ mod tests {
 
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Inactive,
             swipe: Some(SwipeTracker {
@@ -8137,6 +8363,7 @@ mod tests {
 
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Inactive,
             swipe: Some(SwipeTracker {
@@ -8297,6 +8524,122 @@ mod tests {
             listener.matcher,
             ListenerMatcher::KeyEnterPressNoCtrlAltMeta
         )));
+    }
+
+    #[test]
+    fn listeners_for_element_virtual_key_starts_tracker_and_never_focuses() {
+        let mut attrs = Attrs::default();
+        attrs.on_focus = Some(true);
+        attrs.virtual_key = Some(VirtualKeySpec {
+            tap: VirtualKeyTapAction::Text("a".to_string()),
+            hold: VirtualKeyHoldMode::None,
+            hold_ms: 350,
+            repeat_ms: 40,
+        });
+        let element = with_interaction(make_element(73, attrs), true);
+
+        let listeners = listeners_for_element(&element);
+        let press_listener = listener_matching(&listeners, |listener| {
+            matches!(
+                listener.matcher,
+                ListenerMatcher::CursorButtonLeftPressInside { .. }
+            )
+        });
+        let actions = press_listener.compute_actions(&InputEvent::CursorButton {
+            button: "left".to_string(),
+            action: ACTION_PRESS,
+            mods: 0,
+            x: 10.0,
+            y: 10.0,
+        });
+
+        assert!(matches!(
+            actions.as_slice(),
+            [ListenerAction::RuntimeChange(RuntimeChange::StartVirtualKeyTracker { tracker })]
+                if tracker.element_id == ElementId::from_term_bytes(vec![73])
+                    && tracker.phase == VirtualKeyPhase::Armed
+        ));
+
+        let move_actions = listener_matching(&listeners, |listener| {
+            matches!(listener.matcher, ListenerMatcher::CursorPosInside { .. })
+        })
+        .compute_actions(&InputEvent::CursorPos { x: 10.0, y: 10.0 });
+
+        assert_eq!(actions_without_cursor(&move_actions).len(), 0);
+        assert_eq!(cursor_actions(&move_actions), vec![CursorIcon::Pointer]);
+    }
+
+    #[test]
+    fn runtime_listeners_for_overlay_virtual_key_release_dispatches_synthetic_input() {
+        let base = registry_for_elements(&[]);
+        let runtime = RuntimeOverlayState {
+            click_press: None,
+            virtual_key: Some(VirtualKeyTracker {
+                element_id: ElementId::from_term_bytes(vec![74]),
+                region: PointerRegion {
+                    visible: true,
+                    local_shape: ShapeBounds {
+                        rect: Rect {
+                            x: 0.0,
+                            y: 0.0,
+                            width: 100.0,
+                            height: 40.0,
+                        },
+                        radii: None,
+                    },
+                    screen_to_local: Some(Affine2::identity()),
+                    screen_bounds: Rect {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 100.0,
+                        height: 40.0,
+                    },
+                    clip_chain: Vec::new(),
+                },
+                tap: VirtualKeyTapAction::Text("a".to_string()),
+                hold: VirtualKeyHoldMode::None,
+                hold_ms: 350,
+                repeat_ms: 40,
+                phase: VirtualKeyPhase::Armed,
+            }),
+            key_presses: Vec::new(),
+            drag: DragTrackerState::Inactive,
+            swipe: None,
+            scrollbar: None,
+            text_drag: None,
+        };
+
+        let listeners = runtime_listeners_for_overlay(&base, &runtime);
+        assert!(listeners.iter().any(|listener| matches!(
+            listener.matcher,
+            ListenerMatcher::CursorButtonLeftReleaseInside { .. }
+        )));
+        assert!(listeners.iter().any(|listener| matches!(
+            listener.matcher,
+            ListenerMatcher::CursorLocationLeaveBoundary { .. }
+        )));
+
+        let release_listener = listener_matching(&listeners, |listener| {
+            matches!(
+                listener.matcher,
+                ListenerMatcher::CursorButtonLeftReleaseInside { .. }
+            )
+        });
+        let actions = release_listener.compute_actions(&InputEvent::CursorButton {
+            button: "left".to_string(),
+            action: ACTION_RELEASE,
+            mods: 0,
+            x: 10.0,
+            y: 10.0,
+        });
+
+        assert!(matches!(
+            actions.as_slice(),
+            [
+                ListenerAction::SyntheticInput(events),
+                ListenerAction::RuntimeChange(RuntimeChange::ClearVirtualKeyTracker),
+            ] if matches!(events.as_slice(), [InputEvent::TextCommit { text, mods }] if text == "a" && *mods == 0)
+        ));
     }
 
     #[test]
@@ -8470,6 +8813,7 @@ mod tests {
 
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: vec![KeyPressTracker {
                 source_element_id: Some(ElementId::from_term_bytes(vec![40])),
                 key: CanonicalKey::Space,
@@ -9409,6 +9753,7 @@ mod tests {
 
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Inactive,
             swipe: None,
@@ -9467,6 +9812,7 @@ mod tests {
         let base = registry_for_elements(&[]);
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Inactive,
             swipe: None,
@@ -10047,6 +10393,7 @@ mod tests {
         let base = registry_for_elements(&[element]);
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Active {
                 element_id: ElementId::from_term_bytes(vec![48]),
@@ -10106,6 +10453,7 @@ mod tests {
         let base = registry_for_elements(&[element]);
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Active {
                 element_id: ElementId::from_term_bytes(vec![81]),
@@ -10142,6 +10490,7 @@ mod tests {
     fn runtime_listeners_for_overlay_scrollbar_drag_emit_move_and_clear_followups() {
         let runtime = RuntimeOverlayState {
             click_press: None,
+            virtual_key: None,
             key_presses: Vec::new(),
             drag: DragTrackerState::Inactive,
             swipe: None,

--- a/native/emerge_skia/src/events/runtime.rs
+++ b/native/emerge_skia/src/events/runtime.rs
@@ -23,7 +23,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crossbeam_channel::{Receiver, Sender, TrySendError};
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TrySendError};
 use rustler::LocalPid;
 
 use crate::{
@@ -41,6 +41,7 @@ use super::{
     CursorIcon, ElementEventKind, RegistryRebuildPayload, TextInputState, blur_atom, change_atom,
     click_atom, focus_atom, key_down_atom, key_press_atom, key_up_atom, mouse_down_atom,
     mouse_enter_atom, mouse_leave_atom, mouse_move_atom, mouse_up_atom, press_atom,
+    virtual_key_hold_atom,
     registry_builder::{
         self, ListenerAction, ListenerComputeCtx, ListenerInput, ListenerMatcherKind,
         RuntimeChange, RuntimeOverlayState,
@@ -83,6 +84,7 @@ enum DispatchMode {
 struct PendingDispatchEffects {
     tree_msgs: Vec<TreeMsg>,
     runtime_changes: Vec<RuntimeChange>,
+    synthetic_inputs: Vec<Vec<InputEvent>>,
     elixir_event_requires_rebuild: bool,
     requested_cursor: Option<CursorIcon>,
 }
@@ -97,6 +99,7 @@ impl PendingDispatchEffects {
         match action {
             ListenerAction::TreeMsg(msg) => self.tree_msgs.push(msg),
             ListenerAction::RuntimeChange(change) => self.runtime_changes.push(change),
+            ListenerAction::SyntheticInput(events) => self.synthetic_inputs.push(events),
             ListenerAction::SetCursor(icon) => self.requested_cursor = Some(icon),
             ListenerAction::ElixirEvent(event) => {
                 if dispatch_mode == DispatchMode::CursorRevalidate
@@ -126,11 +129,18 @@ impl PendingDispatchEffects {
         runtime: &mut DirectEventRuntime,
         tree_tx: &Sender<TreeMsg>,
         log_render: bool,
-        _dispatch_mode: DispatchMode,
+        dispatch_mode: DispatchMode,
     ) {
         runtime.apply_runtime_changes_and_recompose_if_needed(self.runtime_changes);
         if let Some(icon) = self.requested_cursor {
             runtime.apply_cursor_request(icon);
+        }
+
+        #[cfg(not(feature = "hover-trace"))]
+        let _ = dispatch_mode;
+
+        for events in self.synthetic_inputs {
+            runtime.inject_synthetic_inputs(events, tree_tx, log_render);
         }
 
         if self.elixir_event_requires_rebuild && self.tree_msgs.is_empty() {
@@ -265,6 +275,7 @@ struct DirectEventRuntime {
     last_cursor_pos: Option<(f32, f32)>,
     cursor_in_window: bool,
     current_cursor_icon: CursorIcon,
+    virtual_key_deadline: Option<Instant>,
 }
 
 impl DirectEventRuntime {
@@ -300,6 +311,7 @@ impl DirectEventRuntime {
             last_cursor_pos: None,
             cursor_in_window: false,
             current_cursor_icon: CursorIcon::Default,
+            virtual_key_deadline: None,
         }
     }
 
@@ -334,6 +346,17 @@ impl DirectEventRuntime {
         }
 
         self.dispatch_event(event, tree_tx, log_render, DispatchMode::Normal);
+    }
+
+    fn inject_synthetic_inputs(
+        &mut self,
+        events: Vec<InputEvent>,
+        tree_tx: &Sender<TreeMsg>,
+        log_render: bool,
+    ) {
+        for event in events {
+            self.handle_input_event(event, tree_tx, log_render);
+        }
     }
 
     fn handle_registry_update(
@@ -412,6 +435,73 @@ impl DirectEventRuntime {
         );
     }
 
+    fn next_event_timeout(&self) -> Option<Duration> {
+        self.virtual_key_deadline.map(|deadline| {
+            deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_secs(60))
+        })
+    }
+
+    fn handle_virtual_key_timer(&mut self, tree_tx: &Sender<TreeMsg>, log_render: bool) {
+        let Some(tracker) = self.runtime_overlay.virtual_key.clone() else {
+            self.virtual_key_deadline = None;
+            return;
+        };
+
+        match tracker.phase {
+            registry_builder::VirtualKeyPhase::Armed => match tracker.hold {
+                crate::tree::attrs::VirtualKeyHoldMode::None => {
+                    self.virtual_key_deadline = None;
+                }
+                crate::tree::attrs::VirtualKeyHoldMode::Event => {
+                    self.runtime_overlay.virtual_key = None;
+                    self.virtual_key_deadline = None;
+                    self.recompose_overlay_registry();
+                    self.apply_listener_actions(
+                        vec![ListenerAction::ElixirEvent(registry_builder::ElixirEvent {
+                            element_id: tracker.element_id,
+                            kind: ElementEventKind::VirtualKeyHold,
+                            payload: None,
+                        })],
+                        tree_tx,
+                        log_render,
+                        DispatchMode::Normal,
+                    );
+                }
+                crate::tree::attrs::VirtualKeyHoldMode::Repeat => {
+                    if let Some(active) = self.runtime_overlay.virtual_key.as_mut() {
+                        active.phase = registry_builder::VirtualKeyPhase::Repeating;
+                    }
+
+                    self.virtual_key_deadline = Some(
+                        Instant::now()
+                            + Duration::from_millis(u64::from(tracker.repeat_ms)),
+                    );
+                    self.recompose_overlay_registry();
+                    self.inject_synthetic_inputs(
+                        registry_builder::synthetic_input_sequence_for_virtual_key_tap(&tracker.tap),
+                        tree_tx,
+                        log_render,
+                    );
+                }
+            },
+            registry_builder::VirtualKeyPhase::Repeating => {
+                self.virtual_key_deadline = Some(
+                    Instant::now() + Duration::from_millis(u64::from(tracker.repeat_ms)),
+                );
+                self.inject_synthetic_inputs(
+                    registry_builder::synthetic_input_sequence_for_virtual_key_tap(&tracker.tap),
+                    tree_tx,
+                    log_render,
+                );
+            }
+            registry_builder::VirtualKeyPhase::Cancelled => {
+                self.virtual_key_deadline = None;
+            }
+        }
+    }
+
     fn record_pointer_snapshot(&mut self, event: &InputEvent) {
         match event {
             InputEvent::CursorPos { x, y }
@@ -451,10 +541,12 @@ impl DirectEventRuntime {
 
     fn has_active_pointer_overlay(&self) -> bool {
         self.runtime_overlay.click_press.is_some()
+            || self.runtime_overlay.virtual_key.is_some()
             || !matches!(
                 self.runtime_overlay.drag,
                 registry_builder::DragTrackerState::Inactive
             )
+            || self.runtime_overlay.swipe.is_some()
             || self.runtime_overlay.scrollbar.is_some()
             || self.runtime_overlay.text_drag.is_some()
     }
@@ -568,6 +660,16 @@ impl DirectEventRuntime {
                     emit_press_pointer,
                 });
             }
+            RuntimeChange::StartVirtualKeyTracker { tracker } => {
+                self.virtual_key_deadline = match tracker.hold {
+                    crate::tree::attrs::VirtualKeyHoldMode::Repeat
+                    | crate::tree::attrs::VirtualKeyHoldMode::Event => Some(
+                        Instant::now() + Duration::from_millis(u64::from(tracker.hold_ms)),
+                    ),
+                    crate::tree::attrs::VirtualKeyHoldMode::None => None,
+                };
+                self.runtime_overlay.virtual_key = Some(tracker);
+            }
             RuntimeChange::StartKeyPressTracker { tracker } => {
                 if !self.runtime_overlay.key_presses.contains(&tracker) {
                     self.runtime_overlay.key_presses.push(tracker);
@@ -625,6 +727,16 @@ impl DirectEventRuntime {
             }
             RuntimeChange::ClearSwipeTracker => {
                 self.runtime_overlay.swipe = None;
+            }
+            RuntimeChange::CancelVirtualKeyTracker => {
+                if let Some(ref mut tracker) = self.runtime_overlay.virtual_key {
+                    tracker.phase = registry_builder::VirtualKeyPhase::Cancelled;
+                }
+                self.virtual_key_deadline = None;
+            }
+            RuntimeChange::ClearVirtualKeyTracker => {
+                self.runtime_overlay.virtual_key = None;
+                self.virtual_key_deadline = None;
             }
             RuntimeChange::ClearKeyPressTrackersForKey { key } => {
                 self.runtime_overlay
@@ -707,6 +819,10 @@ impl DirectEventRuntime {
             )
         {
             self.runtime_overlay.click_press = None;
+        }
+
+        if self.runtime_overlay.virtual_key.is_none() {
+            self.virtual_key_deadline = None;
         }
 
         self.runtime_overlay.key_presses.retain(|tracker| {
@@ -829,6 +945,7 @@ fn event_kind_to_atom(kind: ElementEventKind) -> rustler::Atom {
         ElementEventKind::KeyDown => key_down_atom(),
         ElementEventKind::KeyUp => key_up_atom(),
         ElementEventKind::KeyPress => key_press_atom(),
+        ElementEventKind::VirtualKeyHold => virtual_key_hold_atom(),
         ElementEventKind::MouseDown => mouse_down_atom(),
         ElementEventKind::MouseUp => mouse_up_atom(),
         ElementEventKind::MouseEnter => mouse_enter_atom(),
@@ -1272,11 +1389,23 @@ pub(crate) fn spawn_event_actor(
 
         loop {
             let message = match pending_message.take() {
-                Some(message) => message,
-                None => match event_rx.recv() {
-                    Ok(message) => message,
-                    Err(_) => return,
+                Some(message) => Some(message),
+                None => match runtime.next_event_timeout() {
+                    Some(timeout) => match event_rx.recv_timeout(timeout) {
+                        Ok(message) => Some(message),
+                        Err(RecvTimeoutError::Timeout) => None,
+                        Err(RecvTimeoutError::Disconnected) => return,
+                    },
+                    None => match event_rx.recv() {
+                        Ok(message) => Some(message),
+                        Err(_) => return,
+                    },
                 },
+            };
+
+            let Some(message) = message else {
+                runtime.handle_virtual_key_timer(&tree_tx, log_render);
+                continue;
             };
 
             match message {
@@ -1334,12 +1463,16 @@ mod tests {
     use crate::events::registry_builder::{self, FocusRevealScroll};
     use crate::events::test_support::AnimatedNearbyHitCase;
     use crate::events::{CursorIcon, RegistryRebuildPayload};
+    use crate::input::{ACTION_PRESS, ACTION_RELEASE};
     use crate::keys::CanonicalKey;
     use crate::tree::animation::{
         AnimationCurve, AnimationRepeat, AnimationRuntime, AnimationSpec,
     };
     use crate::tree::attrs::TextAlign;
-    use crate::tree::attrs::{AlignX, AlignY, Attrs, Length, MouseOverAttrs};
+    use crate::tree::attrs::{
+        AlignX, AlignY, Attrs, Length, MouseOverAttrs, VirtualKeyHoldMode, VirtualKeySpec,
+        VirtualKeyTapAction,
+    };
     use crate::tree::element::ElementId;
     use crate::tree::element::{
         Element, ElementKind, ElementTree, Frame, NearbySlot, TextInputContentOrigin,
@@ -2501,6 +2634,184 @@ mod tests {
             .expect("session updated after commit");
         assert_eq!(session.content, "abc");
         assert_eq!(session.cursor, 3);
+    }
+
+    #[test]
+    fn direct_runtime_virtual_key_release_commits_text_to_focused_input() {
+        let mut text_attrs = Attrs::default();
+        text_attrs.content = Some("ab".to_string());
+        text_attrs.text_input_focused = Some(true);
+        text_attrs.text_input_cursor = Some(2);
+        let text_input = with_interaction(make_element(80, ElementKind::TextInput, text_attrs));
+
+        let mut key_attrs = Attrs::default();
+        key_attrs.virtual_key = Some(VirtualKeySpec {
+            tap: VirtualKeyTapAction::Text("c".to_string()),
+            hold: VirtualKeyHoldMode::None,
+            hold_ms: 350,
+            repeat_ms: 40,
+        });
+        let soft_key = with_interaction_rect(make_element(81, ElementKind::El, key_attrs), 0.0, 50.0, 100.0, 40.0);
+
+        let rebuild = RegistryRebuildPayload {
+            base_registry: registry_builder::registry_for_elements(&[text_input, soft_key]),
+            text_inputs: HashMap::from([(
+                ElementId::from_term_bytes(vec![80]),
+                make_text_input_state("ab", 2, None, true),
+            )]),
+            scrollbars: HashMap::new(),
+            focused_id: Some(ElementId::from_term_bytes(vec![80])),
+        };
+
+        let (tree_tx, tree_rx) = bounded(64);
+        let mut runtime = DirectEventRuntime::new(false);
+        runtime.handle_registry_update(rebuild.clone(), &tree_tx, false);
+        let _ = drain_msgs(&tree_rx);
+        runtime.handle_registry_update(rebuild, &tree_tx, false);
+        assert!(!runtime.listener_lane.is_stale());
+
+        runtime.handle_input_event(
+            InputEvent::CursorButton {
+                button: "left".to_string(),
+                action: ACTION_PRESS,
+                mods: 0,
+                x: 10.0,
+                y: 60.0,
+            },
+            &tree_tx,
+            false,
+        );
+        let _ = drain_msgs(&tree_rx);
+        assert!(runtime.runtime_overlay.virtual_key.is_some());
+
+        runtime.handle_input_event(
+            InputEvent::CursorButton {
+                button: "left".to_string(),
+                action: ACTION_RELEASE,
+                mods: 0,
+                x: 10.0,
+                y: 60.0,
+            },
+            &tree_tx,
+            false,
+        );
+
+        assert!(runtime.listener_lane.is_stale());
+        assert!(runtime.runtime_overlay.virtual_key.is_none());
+
+        let msgs = drain_msgs(&tree_rx);
+        assert!(msgs.iter().any(|msg| matches!(
+            msg,
+            TreeMsg::SetTextInputContent { element_id, content }
+                if *element_id == ElementId::from_term_bytes(vec![80]) && content == "abc"
+        )));
+
+        let session = runtime
+            .text_states
+            .get(&ElementId::from_term_bytes(vec![80]))
+            .expect("session updated after virtual key tap");
+        assert_eq!(session.content, "abc");
+        assert_eq!(session.cursor, 3);
+    }
+
+    #[test]
+    fn direct_runtime_virtual_key_repeat_stops_after_slide_off_until_repress() {
+        let mut text_attrs = Attrs::default();
+        text_attrs.content = Some("ab".to_string());
+        text_attrs.text_input_focused = Some(true);
+        text_attrs.text_input_cursor = Some(2);
+        let text_input = with_interaction(make_element(82, ElementKind::TextInput, text_attrs));
+
+        let mut key_attrs = Attrs::default();
+        key_attrs.virtual_key = Some(VirtualKeySpec {
+            tap: VirtualKeyTapAction::Text("x".to_string()),
+            hold: VirtualKeyHoldMode::Repeat,
+            hold_ms: 350,
+            repeat_ms: 40,
+        });
+        let soft_key = with_interaction_rect(make_element(83, ElementKind::El, key_attrs), 0.0, 50.0, 100.0, 40.0);
+
+        let rebuild = RegistryRebuildPayload {
+            base_registry: registry_builder::registry_for_elements(&[text_input.clone(), soft_key.clone()]),
+            text_inputs: HashMap::from([(
+                ElementId::from_term_bytes(vec![82]),
+                make_text_input_state("ab", 2, None, true),
+            )]),
+            scrollbars: HashMap::new(),
+            focused_id: Some(ElementId::from_term_bytes(vec![82])),
+        };
+
+        let (tree_tx, tree_rx) = bounded(64);
+        let mut runtime = DirectEventRuntime::new(false);
+        runtime.handle_registry_update(rebuild.clone(), &tree_tx, false);
+        let _ = drain_msgs(&tree_rx);
+        runtime.handle_registry_update(rebuild, &tree_tx, false);
+
+        runtime.handle_input_event(
+            InputEvent::CursorButton {
+                button: "left".to_string(),
+                action: ACTION_PRESS,
+                mods: 0,
+                x: 10.0,
+                y: 60.0,
+            },
+            &tree_tx,
+            false,
+        );
+        assert!(matches!(
+            runtime.runtime_overlay.virtual_key.as_ref().map(|tracker| tracker.phase),
+            Some(registry_builder::VirtualKeyPhase::Armed)
+        ));
+
+        runtime.handle_virtual_key_timer(&tree_tx, false);
+
+        assert!(matches!(
+            runtime.runtime_overlay.virtual_key.as_ref().map(|tracker| tracker.phase),
+            Some(registry_builder::VirtualKeyPhase::Repeating)
+        ));
+
+        let msgs = drain_msgs(&tree_rx);
+        assert!(msgs.iter().any(|msg| matches!(
+            msg,
+            TreeMsg::SetTextInputContent { element_id, content }
+                if *element_id == ElementId::from_term_bytes(vec![82]) && content == "abx"
+        )));
+
+        let repeat_rebuild = RegistryRebuildPayload {
+            base_registry: registry_builder::registry_for_elements(&[text_input, soft_key]),
+            text_inputs: HashMap::from([(
+                ElementId::from_term_bytes(vec![82]),
+                make_text_input_state_with_origin("abx", TextInputContentOrigin::Event, 3, None, true),
+            )]),
+            scrollbars: HashMap::new(),
+            focused_id: Some(ElementId::from_term_bytes(vec![82])),
+        };
+        runtime.handle_registry_update(repeat_rebuild, &tree_tx, false);
+        let _ = drain_msgs(&tree_rx);
+        assert!(!runtime.listener_lane.is_stale());
+
+        runtime.handle_input_event(InputEvent::CursorPos { x: 140.0, y: 60.0 }, &tree_tx, false);
+        runtime.handle_input_event(InputEvent::CursorPos { x: 10.0, y: 60.0 }, &tree_tx, false);
+
+        assert!(matches!(
+            runtime.runtime_overlay.virtual_key.as_ref().map(|tracker| tracker.phase),
+            Some(registry_builder::VirtualKeyPhase::Cancelled)
+        ));
+        assert!(runtime.virtual_key_deadline.is_none());
+
+        runtime.handle_virtual_key_timer(&tree_tx, false);
+        let msgs = drain_msgs(&tree_rx);
+        assert!(msgs.iter().all(|msg| !matches!(
+            msg,
+            TreeMsg::SetTextInputContent { element_id, content }
+                if *element_id == ElementId::from_term_bytes(vec![82]) && content == "abxx"
+        )));
+
+        let session = runtime
+            .text_states
+            .get(&ElementId::from_term_bytes(vec![82]))
+            .expect("session retained after repeat cancel");
+        assert_eq!(session.content, "abx");
     }
 
     #[test]

--- a/native/emerge_skia/src/tree/attrs.rs
+++ b/native/emerge_skia/src/tree/attrs.rs
@@ -221,6 +221,35 @@ pub struct KeyBindingSpec {
     pub match_mode: KeyBindingMatch,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VirtualKeyTapAction {
+    Text(String),
+    Key {
+        key: CanonicalKey,
+        mods: u8,
+    },
+    TextAndKey {
+        text: String,
+        key: CanonicalKey,
+        mods: u8,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VirtualKeyHoldMode {
+    None,
+    Repeat,
+    Event,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VirtualKeySpec {
+    pub tap: VirtualKeyTapAction,
+    pub hold: VirtualKeyHoldMode,
+    pub hold_ms: u32,
+    pub repeat_ms: u32,
+}
+
 /// All decoded attributes for an element.
 #[derive(Clone, Debug, Default)]
 pub struct Attrs {
@@ -258,6 +287,7 @@ pub struct Attrs {
     pub on_key_down: Option<Vec<KeyBindingSpec>>,
     pub on_key_up: Option<Vec<KeyBindingSpec>>,
     pub on_key_press: Option<Vec<KeyBindingSpec>>,
+    pub virtual_key: Option<VirtualKeySpec>,
     pub mouse_over: Option<MouseOverAttrs>,
     pub focused: Option<MouseOverAttrs>,
     pub mouse_down: Option<MouseOverAttrs>,
@@ -505,6 +535,7 @@ const TAG_ON_SWIPE_UP: u8 = 71;
 const TAG_ON_SWIPE_DOWN: u8 = 72;
 const TAG_ON_SWIPE_LEFT: u8 = 73;
 const TAG_ON_SWIPE_RIGHT: u8 = 74;
+const TAG_VIRTUAL_KEY: u8 = 75;
 
 // =============================================================================
 // Decoder
@@ -646,6 +677,7 @@ fn decode_attr(cursor: &mut AttrCursor, tag: u8, attrs: &mut Attrs) -> Result<()
         TAG_ON_KEY_DOWN => attrs.on_key_down = Some(decode_key_bindings(cursor)?),
         TAG_ON_KEY_UP => attrs.on_key_up = Some(decode_key_bindings(cursor)?),
         TAG_ON_KEY_PRESS => attrs.on_key_press = Some(decode_key_bindings(cursor)?),
+        TAG_VIRTUAL_KEY => attrs.virtual_key = Some(decode_virtual_key(cursor)?),
         TAG_MOUSE_OVER => {
             attrs.mouse_over = Some(decode_decorative_style_attrs(cursor, "mouse_over")?)
         }
@@ -869,6 +901,82 @@ fn decode_key_bindings(cursor: &mut AttrCursor) -> Result<Vec<KeyBindingSpec>, D
     }
 
     Ok(bindings)
+}
+
+fn decode_virtual_key(cursor: &mut AttrCursor) -> Result<VirtualKeySpec, DecodeError> {
+    let data = cursor.read_bytes_u32()?;
+    let mut nested = AttrCursor::new(&data);
+
+    let tap_tag = nested.read_u8()?;
+    let hold_tag = nested.read_u8()?;
+    let hold_ms = nested.read_u32_be()?;
+    let repeat_ms = nested.read_u32_be()?;
+
+    let tap = match tap_tag {
+        0 => VirtualKeyTapAction::Text(nested.read_string_u16()?),
+        1 => {
+            let key_name = nested.read_string_u16()?;
+            let Some(key) = CanonicalKey::from_atom_name(&key_name) else {
+                return Err(DecodeError::InvalidStructure(format!(
+                    "unknown virtual key canonical key: {}",
+                    key_name
+                )));
+            };
+
+            VirtualKeyTapAction::Key {
+                key,
+                mods: nested.read_u8()?,
+            }
+        }
+        2 => {
+            let text = nested.read_string_u16()?;
+            let key_name = nested.read_string_u16()?;
+            let Some(key) = CanonicalKey::from_atom_name(&key_name) else {
+                return Err(DecodeError::InvalidStructure(format!(
+                    "unknown virtual key canonical key: {}",
+                    key_name
+                )));
+            };
+
+            VirtualKeyTapAction::TextAndKey {
+                text,
+                key,
+                mods: nested.read_u8()?,
+            }
+        }
+        other => {
+            return Err(DecodeError::InvalidStructure(format!(
+                "unknown virtual key tap tag: {}",
+                other
+            )));
+        }
+    };
+
+    let hold = match hold_tag {
+        0 => VirtualKeyHoldMode::None,
+        1 => VirtualKeyHoldMode::Repeat,
+        2 => VirtualKeyHoldMode::Event,
+        other => {
+            return Err(DecodeError::InvalidStructure(format!(
+                "unknown virtual key hold tag: {}",
+                other
+            )));
+        }
+    };
+
+    if nested.remaining() != 0 {
+        return Err(DecodeError::InvalidStructure(format!(
+            "virtual key payload has {} trailing bytes",
+            nested.remaining(),
+        )));
+    }
+
+    Ok(VirtualKeySpec {
+        tap,
+        hold,
+        hold_ms,
+        repeat_ms,
+    })
 }
 
 fn decode_length(cursor: &mut AttrCursor) -> Result<Length, DecodeError> {
@@ -1654,6 +1762,50 @@ mod tests {
         let attrs = decode_attrs(&data).unwrap();
         assert_eq!(attrs.on_focus, Some(true));
         assert_eq!(attrs.on_blur, Some(true));
+    }
+
+    #[test]
+    fn test_decode_virtual_key_text_and_key_with_hold_event() {
+        let mut payload = vec![2, 2];
+        payload.extend_from_slice(&280_u32.to_be_bytes());
+        payload.extend_from_slice(&55_u32.to_be_bytes());
+        payload.extend_from_slice(&[0, 1, b'A']);
+        payload.extend_from_slice(&[0, 1, b'a']);
+        payload.push(0x01);
+
+        let mut data = vec![0, 1, TAG_VIRTUAL_KEY];
+        data.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        data.extend_from_slice(&payload);
+
+        let attrs = decode_attrs(&data).unwrap();
+        assert_eq!(
+            attrs.virtual_key,
+            Some(VirtualKeySpec {
+                tap: VirtualKeyTapAction::TextAndKey {
+                    text: "A".to_string(),
+                    key: CanonicalKey::A,
+                    mods: 0x01,
+                },
+                hold: VirtualKeyHoldMode::Event,
+                hold_ms: 280,
+                repeat_ms: 55,
+            })
+        );
+    }
+
+    #[test]
+    fn test_decode_virtual_key_rejects_unknown_hold_tag() {
+        let mut payload = vec![0, 9];
+        payload.extend_from_slice(&350_u32.to_be_bytes());
+        payload.extend_from_slice(&40_u32.to_be_bytes());
+        payload.extend_from_slice(&[0, 1, b'a']);
+
+        let mut data = vec![0, 1, TAG_VIRTUAL_KEY];
+        data.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        data.extend_from_slice(&payload);
+
+        let err = decode_attrs(&data).unwrap_err();
+        assert!(err.to_string().contains("unknown virtual key hold tag: 9"));
     }
 
     #[test]

--- a/native/emerge_skia/src/tree/layout.rs
+++ b/native/emerge_skia/src/tree/layout.rs
@@ -465,6 +465,7 @@ fn scale_attrs(attrs: &Attrs, scale: f32) -> Attrs {
         on_key_down: attrs.on_key_down.clone(),
         on_key_up: attrs.on_key_up.clone(),
         on_key_press: attrs.on_key_press.clone(),
+        virtual_key: attrs.virtual_key.clone(),
         mouse_over: attrs
             .mouse_over
             .as_ref()

--- a/native/emerge_skia/src/tree/patch.rs
+++ b/native/emerge_skia/src/tree/patch.rs
@@ -655,6 +655,7 @@ fn sanitize_ghost_visual(kind: ElementKind, source: &Attrs) -> (ElementKind, Att
     attrs.on_change = None;
     attrs.on_focus = None;
     attrs.on_blur = None;
+    attrs.virtual_key = None;
 
     attrs.mouse_over = None;
     attrs.focused = None;

--- a/test/emerge/attr_codec_test.exs
+++ b/test/emerge/attr_codec_test.exs
@@ -196,6 +196,23 @@ defmodule Emerge.Engine.AttrCodecTest do
            }
   end
 
+  test "encode/decode virtual key descriptor" do
+    attrs = %{
+      virtual_key:
+        Event.virtual_key(
+          tap: {:text_and_key, "A", :a, [:shift]},
+          hold: {:event, {self(), :show_alternates}},
+          hold_ms: 280,
+          repeat_ms: 55
+        )
+        |> elem(1)
+    }
+
+    decoded = attrs |> AttrCodec.encode_attrs() |> AttrCodec.decode_attrs()
+
+    assert normalize_attrs(decoded) == normalize_attrs(attrs)
+  end
+
   test "encode/decode mouse_over decorative attrs" do
     attrs = %{
       mouse_over: %{
@@ -576,7 +593,10 @@ defmodule Emerge.Engine.AttrCodecTest do
     attrs
     |> Emerge.Engine.Tree.strip_runtime_attrs()
     |> Emerge.Engine.Tree.strip_nearby_attrs()
-    |> Enum.map(fn {key, value} -> {key, normalize_value(value)} end)
+    |> Enum.map(fn
+      {:virtual_key, value} -> {:virtual_key, Event.virtual_key_descriptor(value)}
+      {key, value} -> {key, normalize_value(value)}
+    end)
     |> Map.new()
   end
 

--- a/test/emerge/diff_state_test.exs
+++ b/test/emerge/diff_state_test.exs
@@ -335,6 +335,25 @@ defmodule Emerge.Engine.DiffStateTest do
     assert cycle_pid == self()
   end
 
+  test "virtual key hold event is registered in event registry" do
+    layout =
+      Emerge.UI.Input.button(
+        [
+          key(:soft_a),
+          Event.virtual_key(tap: {:text, "a"}, hold: {:event, {self(), :show_alternates}})
+        ],
+        Emerge.UI.text("A")
+      )
+
+    state = Emerge.Engine.diff_state_new(layout)
+    id_bin = :erlang.term_to_binary(state.tree.id)
+
+    assert {:ok, {pid, :show_alternates}} =
+             Emerge.Engine.lookup_event(state, id_bin, :virtual_key_hold)
+
+    assert pid == self()
+  end
+
   test "text input registers click and mouse handlers alongside on_change" do
     layout =
       Emerge.UI.Input.text(
@@ -445,6 +464,23 @@ defmodule Emerge.Engine.DiffStateTest do
              )
 
     assert_receive :cycled
+  end
+
+  test "dispatch_event routes virtual key hold events" do
+    layout =
+      Emerge.UI.Input.button(
+        [
+          key(:soft_a),
+          Event.virtual_key(tap: {:text, "a"}, hold: {:event, {self(), :show_alternates}})
+        ],
+        Emerge.UI.text("A")
+      )
+
+    state = Emerge.Engine.diff_state_new(layout)
+    id_bin = :erlang.term_to_binary(state.tree.id)
+
+    assert :ok == Emerge.Engine.dispatch_event(state, id_bin, :virtual_key_hold)
+    assert_receive :show_alternates
   end
 
   defp content_id_map(%Emerge.Engine.Element{children: children}) do

--- a/test/emerge/ui_test.exs
+++ b/test/emerge/ui_test.exs
@@ -730,6 +730,51 @@ defmodule Emerge.UITest do
     assert press_binding.route == Event.key_route_id(:key_press, :space, [], :exact)
   end
 
+  test "virtual_key helper returns normalized spec" do
+    assert {:virtual_key, spec} =
+             Event.virtual_key(
+               tap: {:text_and_key, "A", :a, [:shift]},
+               hold: {:event, {self(), :show_alternates}},
+               hold_ms: 280,
+               repeat_ms: 55
+             )
+
+    assert spec == %{
+             tap: {:text_and_key, "A", :a, [:shift]},
+             hold: {:event, {self(), :show_alternates}},
+             hold_ms: 280,
+             repeat_ms: 55
+           }
+  end
+
+  test "virtual_key helper applies defaults" do
+    assert {:virtual_key, spec} = Event.virtual_key(tap: {:key, :enter, []})
+
+    assert spec == %{
+             tap: {:key, :enter, []},
+             hold: nil,
+             hold_ms: 350,
+             repeat_ms: 40
+           }
+  end
+
+  test "virtual_key rejects on_click and on_press conflicts" do
+    assert_raise ArgumentError,
+                 ~r/does not allow :virtual_key together with :on_click or :on_press/,
+                 fn ->
+                   Input.button(
+                     [Event.virtual_key(tap: {:text, "a"}), Event.on_press(:pressed)],
+                     text("A")
+                   )
+                 end
+
+    assert_raise ArgumentError,
+                 ~r/does not allow :virtual_key together with :on_click or :on_press/,
+                 fn ->
+                   el([Event.virtual_key(tap: {:text, "a"}), Event.on_click(:clicked)], text("A"))
+                 end
+  end
+
   test "Input.text creates a text_input element" do
     element =
       Emerge.UI.Input.text(


### PR DESCRIPTION
Add a dedicated virtual_key input path so plain Emerge nodes can inject text, canonical keys, hold events, and repeat behavior without stealing focus. Include an input demo that exercises shifted letters, alternates, and repeat keys against focused controls.