### PR TITLE
fix precompiled nif workflow args

### DIFF
--- a/.github/workflows/precompiled_nifs.yml
+++ b/.github/workflows/precompiled_nifs.yml
@@ -37,7 +37,7 @@ jobs:
             os: ubuntu-24.04
             use_cross: false
             variant: "drm_wayland"
-            cargo_args: "--no-default-features --features wayland drm"
+            cargo_args: "--no-default-features --features wayland,drm"
             system_packages: "libegl1-mesa-dev libgbm-dev libdrm-dev libfontconfig1-dev libfreetype6-dev libwayland-dev libxkbcommon-dev"
           - name: linux_aarch64_wayland
             target: aarch64-unknown-linux-gnu
@@ -58,7 +58,7 @@ jobs:
             os: ubuntu-24.04-arm
             use_cross: false
             variant: "drm_wayland"
-            cargo_args: "--no-default-features --features wayland drm"
+            cargo_args: "--no-default-features --features wayland,drm"
             system_packages: "libegl1-mesa-dev libgbm-dev libdrm-dev libfontconfig1-dev libfreetype6-dev libwayland-dev libxkbcommon-dev"
 
     steps:
@@ -96,7 +96,7 @@ jobs:
           project-version: ${{ env.PROJECT_VERSION }}
           target: ${{ matrix.job.target }}
           nif-version: ${{ matrix.nif }}
-          use-cross: ${{ matrix.job.use_cross }}
+          use-cross: ${{ matrix.job.use_cross && 'true' || '' }}
           project-dir: native/emerge_skia
           variant: ${{ matrix.job.variant }}
           cargo-args: ${{ matrix.job.cargo_args }}


### PR DESCRIPTION
Pass combined cargo features in a single argument and only enable cross when a matrix job actually requests it, so host and arm precompile jobs use the expected build tool.