### PR TITLE
fix release checksum generation

### DIFF
--- a/.github/workflows/precompiled_nifs.yml
+++ b/.github/workflows/precompiled_nifs.yml
@@ -73,7 +73,25 @@ jobs:
 
       - name: Extract project version
         shell: bash
-        run: echo "PROJECT_VERSION=$(mix emerge.version)" >> "$GITHUB_ENV"
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            project_version="${GITHUB_REF_NAME#v}"
+          else
+            project_version="$(mix emerge.version)"
+            project_version="${project_version##*$'\n'}"
+          fi
+
+          if [[ -z "$project_version" ]]; then
+            echo "Failed to resolve project version" >&2
+            exit 1
+          fi
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* && "v${project_version}" != "${GITHUB_REF_NAME}" ]]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match project version ${project_version}" >&2
+            exit 1
+          fi
+
+          echo "PROJECT_VERSION=$project_version" >> "$GITHUB_ENV"
 
       - name: Install Linux build dependencies
         if: ${{ matrix.job.system_packages != '' }}

--- a/.github/workflows/private_hex_release.yml
+++ b/.github/workflows/private_hex_release.yml
@@ -77,7 +77,9 @@ jobs:
 
       - name: Generate precompiled checksum file
         env:
+          EMERGE_SKIA_CHECKSUM_ONLY: "true"
           EMERGE_SKIA_GITHUB_TOKEN: ${{ secrets.EMERGE_SKIA_GITHUB_TOKEN || github.token }}
+          MIX_ENV: prod
         run: mix rustler_precompiled.download EmergeSkia.Native --all --print
 
       - name: Verify Hex package contents

--- a/lib/emerge_skia/build_config.ex
+++ b/lib/emerge_skia/build_config.ex
@@ -3,6 +3,7 @@ defmodule EmergeSkia.BuildConfig do
 
   @version Mix.Project.config()[:version]
   @force_precompiled_build_env_key "EMERGE_SKIA_BUILD"
+  @checksum_only_env_key "EMERGE_SKIA_CHECKSUM_ONLY"
   @github_token_env_key "EMERGE_SKIA_GITHUB_TOKEN"
   @precompiled_source_url_env_key "EMERGE_SKIA_PRECOMPILED_SOURCE_URL"
   @precompiled_targets ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
@@ -115,6 +116,9 @@ defmodule EmergeSkia.BuildConfig do
   def force_precompiled_build_env_key, do: @force_precompiled_build_env_key
 
   @doc false
+  def checksum_only_env_key, do: @checksum_only_env_key
+
+  @doc false
   def precompiled_targets, do: @precompiled_targets
 
   @doc false
@@ -125,6 +129,11 @@ defmodule EmergeSkia.BuildConfig do
 
   @doc false
   def precompiled_source_url_env_key, do: @precompiled_source_url_env_key
+
+  @doc false
+  def checksum_only_mode?(env \\ System.get_env()) when is_map(env) do
+    Map.get(env, @checksum_only_env_key) in ["1", "true"]
+  end
 
   @doc false
   def default_compiled_backends(env) when is_map(env) do

--- a/lib/emerge_skia/checksum_metadata.ex
+++ b/lib/emerge_skia/checksum_metadata.ex
@@ -1,0 +1,72 @@
+defmodule EmergeSkia.ChecksumMetadata do
+  @moduledoc false
+
+  @doc false
+  def ensure_written!(nif_module, opts) when is_atom(nif_module) and is_list(opts) do
+    env = Keyword.get(opts, :env, System.get_env())
+    metadata = metadata_from_options(opts)
+    metadata_file = metadata_file_path(nif_module, env)
+
+    if Map.equal?(metadata, read_map_from_file(metadata_file)) do
+      :ok
+    else
+      metadata_file
+      |> Path.dirname()
+      |> File.mkdir_p!()
+
+      File.write!(metadata_file, inspect(metadata, limit: :infinity, pretty: true))
+    end
+
+    :ok
+  end
+
+  @doc false
+  def metadata_file_path(nif_module, env \\ System.get_env())
+      when is_atom(nif_module) and is_map(env) do
+    metadata_cache_dir(env)
+    |> Path.join("metadata-#{nif_module}.exs")
+  end
+
+  @doc false
+  def metadata_from_options(opts) when is_list(opts) do
+    variants = Keyword.get(opts, :variants, %{})
+    otp_app = Keyword.fetch!(opts, :otp_app)
+
+    %{
+      base_url: Keyword.fetch!(opts, :base_url),
+      basename: Keyword.get(opts, :crate) || otp_app,
+      crate: Keyword.get(opts, :crate),
+      otp_app: otp_app,
+      targets: Keyword.fetch!(opts, :targets),
+      variants: variant_names(variants),
+      nif_versions: Keyword.fetch!(opts, :nif_versions),
+      version: Keyword.fetch!(opts, :version)
+    }
+  end
+
+  defp metadata_cache_dir(env) when is_map(env) do
+    case Map.get(env, "RUSTLER_PRECOMPILED_GLOBAL_CACHE_PATH") do
+      path when is_binary(path) and path != "" ->
+        path
+
+      _ ->
+        cache_opts = if Map.get(env, "MIX_XDG"), do: %{os: :linux}, else: %{}
+
+        :filename.basedir(:user_cache, Path.join("rustler_precompiled", "metadata"), cache_opts)
+        |> to_string()
+    end
+  end
+
+  defp variant_names(variants) when is_map(variants) do
+    Map.new(variants, fn {target, values} -> {target, Keyword.keys(values)} end)
+  end
+
+  defp read_map_from_file(file) do
+    with {:ok, contents} <- File.read(file),
+         {%{} = contents, _} <- Code.eval_string(contents) do
+      contents
+    else
+      _ -> %{}
+    end
+  end
+end

--- a/lib/emerge_skia/native.ex
+++ b/lib/emerge_skia/native.ex
@@ -5,37 +5,56 @@ defmodule EmergeSkia.Native do
 
   @version Mix.Project.config()[:version]
   @base_url {EmergeSkia.BuildConfig, :precompiled_tar_gz_url}
-  @rustler_opts Mix.Project.config()[:rustler_opts] || []
-  @compiled_backends EmergeSkia.BuildConfig.compiled_backends()
-  @checksum_path Path.expand("../../checksum-Elixir.EmergeSkia.Native.exs", __DIR__)
   @precompiled_targets EmergeSkia.BuildConfig.precompiled_targets()
   @precompiled_nif_versions EmergeSkia.BuildConfig.precompiled_nif_versions()
-  @precompiled_variants EmergeSkia.BuildConfig.precompiled_variants()
-  @cargo_features EmergeSkia.BuildConfig.compiled_backends_to_rustler_features(@compiled_backends)
-  @force_build EmergeSkia.BuildConfig.force_precompiled_build?(
-                 checksum_path: @checksum_path,
-                 compiled_backends: @compiled_backends,
-                 targets: @precompiled_targets,
-                 nif_versions: @precompiled_nif_versions
-               )
+  @checksum_only EmergeSkia.BuildConfig.checksum_only_mode?()
 
-  use RustlerPrecompiled,
-      Keyword.merge(
-        [
-          otp_app: :emerge,
-          crate: "emerge_skia",
-          base_url: @base_url,
-          version: @version,
-          force_build: @force_build,
-          targets: @precompiled_targets,
-          nif_versions: @precompiled_nif_versions,
-          variants: @precompiled_variants,
-          path: "native/emerge_skia",
-          default_features: false,
-          features: @cargo_features
-        ],
-        @rustler_opts
+  if @checksum_only do
+    # Checksum generation only needs RustlerPrecompiled metadata, not a built or downloaded NIF.
+    :ok =
+      EmergeSkia.ChecksumMetadata.ensure_written!(
+        __MODULE__,
+        otp_app: :emerge,
+        crate: "emerge_skia",
+        base_url: @base_url,
+        version: @version,
+        targets: @precompiled_targets,
+        nif_versions: @precompiled_nif_versions,
+        variants: EmergeSkia.BuildConfig.precompiled_variants()
       )
+  else
+    @rustler_opts Mix.Project.config()[:rustler_opts] || []
+    @compiled_backends EmergeSkia.BuildConfig.compiled_backends()
+    @checksum_path Path.expand("../../checksum-Elixir.EmergeSkia.Native.exs", __DIR__)
+    @precompiled_variants EmergeSkia.BuildConfig.precompiled_variants()
+    @cargo_features EmergeSkia.BuildConfig.compiled_backends_to_rustler_features(
+                      @compiled_backends
+                    )
+    @force_build EmergeSkia.BuildConfig.force_precompiled_build?(
+                   checksum_path: @checksum_path,
+                   compiled_backends: @compiled_backends,
+                   targets: @precompiled_targets,
+                   nif_versions: @precompiled_nif_versions
+                 )
+
+    use RustlerPrecompiled,
+        Keyword.merge(
+          [
+            otp_app: :emerge,
+            crate: "emerge_skia",
+            base_url: @base_url,
+            version: @version,
+            force_build: @force_build,
+            targets: @precompiled_targets,
+            nif_versions: @precompiled_nif_versions,
+            variants: @precompiled_variants,
+            path: "native/emerge_skia",
+            default_features: false,
+            features: @cargo_features
+          ],
+          @rustler_opts
+        )
+  end
 
   @doc """
   Start the Skia renderer with a window.

--- a/test/emerge_skia/build_config_test.exs
+++ b/test/emerge_skia/build_config_test.exs
@@ -126,6 +126,11 @@ defmodule EmergeSkia.BuildConfigTest do
              "https://github.com/acme/emerge/releases/download/v#{Mix.Project.config()[:version]}/demo.tar.gz"
   end
 
+  test "checksum_only_mode? respects the checksum generation env var" do
+    assert BuildConfig.checksum_only_mode?(%{BuildConfig.checksum_only_env_key() => "true"})
+    refute BuildConfig.checksum_only_mode?(%{})
+  end
+
   test "force_precompiled_build? forces builds when checksum is missing" do
     assert BuildConfig.force_precompiled_build?(
              checksum_path: "/tmp/emerge-missing-checksum",

--- a/test/emerge_skia/checksum_metadata_test.exs
+++ b/test/emerge_skia/checksum_metadata_test.exs
@@ -1,0 +1,61 @@
+defmodule EmergeSkia.ChecksumMetadataTest do
+  use ExUnit.Case, async: false
+
+  alias EmergeSkia.BuildConfig
+  alias EmergeSkia.ChecksumMetadata
+
+  test "writes metadata that rustler_precompiled can use for checksum downloads" do
+    cache_path =
+      Path.join(
+        System.tmp_dir!(),
+        "emerge-rustler-precompiled-#{System.unique_integer([:positive])}"
+      )
+
+    restore_env_on_exit("RUSTLER_PRECOMPILED_GLOBAL_CACHE_PATH")
+    restore_env_on_exit("MIX_XDG")
+
+    System.put_env("RUSTLER_PRECOMPILED_GLOBAL_CACHE_PATH", cache_path)
+    System.delete_env("MIX_XDG")
+
+    :ok =
+      ChecksumMetadata.ensure_written!(
+        EmergeSkia.Native,
+        otp_app: :emerge,
+        crate: "emerge_skia",
+        base_url: {BuildConfig, :precompiled_tar_gz_url},
+        version: Mix.Project.config()[:version],
+        targets: BuildConfig.precompiled_targets(),
+        nif_versions: BuildConfig.precompiled_nif_versions(),
+        variants: BuildConfig.precompiled_variants()
+      )
+
+    assert File.exists?(ChecksumMetadata.metadata_file_path(EmergeSkia.Native))
+
+    version = Mix.Project.config()[:version]
+
+    assert RustlerPrecompiled.available_nifs(EmergeSkia.Native)
+           |> Enum.map(&elem(&1, 0))
+           |> Enum.sort() == [
+             "libemerge_skia-v#{version}-nif-2.15-aarch64-unknown-linux-gnu--drm.so.tar.gz",
+             "libemerge_skia-v#{version}-nif-2.15-aarch64-unknown-linux-gnu--drm_wayland.so.tar.gz",
+             "libemerge_skia-v#{version}-nif-2.15-aarch64-unknown-linux-gnu.so.tar.gz",
+             "libemerge_skia-v#{version}-nif-2.15-x86_64-unknown-linux-gnu--drm.so.tar.gz",
+             "libemerge_skia-v#{version}-nif-2.15-x86_64-unknown-linux-gnu--drm_wayland.so.tar.gz",
+             "libemerge_skia-v#{version}-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz"
+           ]
+
+    on_exit(fn -> File.rm_rf!(cache_path) end)
+  end
+
+  defp restore_env_on_exit(name) do
+    previous = System.get_env(name)
+
+    on_exit(fn ->
+      if previous do
+        System.put_env(name, previous)
+      else
+        System.delete_env(name)
+      end
+    end)
+  end
+end


### PR DESCRIPTION
Avoid rebuilding the native crate when generating precompiled checksums and derive release asset versions from the pushed tag so RustlerPrecompiled looks for the correct filenames.