### PR TITLE
fix public release downloads

### DIFF
--- a/.github/workflows/private_hex_release.yml
+++ b/.github/workflows/private_hex_release.yml
@@ -78,19 +78,15 @@ jobs:
       - name: Generate precompiled checksum file
         env:
           EMERGE_SKIA_CHECKSUM_ONLY: "true"
-          EMERGE_SKIA_GITHUB_TOKEN: ${{ secrets.EMERGE_SKIA_GITHUB_TOKEN || github.token }}
           MIX_ENV: prod
         run: mix rustler_precompiled.download EmergeSkia.Native --all --print
 
       - name: Verify Hex package contents
-        env:
-          EMERGE_SKIA_GITHUB_TOKEN: ${{ secrets.EMERGE_SKIA_GITHUB_TOKEN || github.token }}
         run: mix hex.build --unpack
 
       - name: Publish package and docs to Hex
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
-          EMERGE_SKIA_GITHUB_TOKEN: ${{ secrets.EMERGE_SKIA_GITHUB_TOKEN || github.token }}
         shell: bash
         run: |
           if [ -n "$HEX_ORGANIZATION" ]; then

--- a/lib/emerge_skia/build_config.ex
+++ b/lib/emerge_skia/build_config.ex
@@ -302,7 +302,8 @@ defmodule EmergeSkia.BuildConfig do
         {url,
          [
            {"Authorization", "Bearer #{token}"},
-           {"Accept", "application/octet-stream"}
+           {"Accept", "application/octet-stream"},
+           {"User-Agent", "emerge-skia-precompiled"}
          ]}
 
       _ ->
@@ -319,7 +320,8 @@ defmodule EmergeSkia.BuildConfig do
         [
           {"Authorization", "Bearer #{token}"},
           {"Accept", "application/octet-stream"},
-          {"X-GitHub-Api-Version", "2022-11-28"}
+          {"X-GitHub-Api-Version", "2022-11-28"},
+          {"User-Agent", "emerge-skia-precompiled"}
         ]}}
     else
       _ -> :error

--- a/test/emerge_skia/build_config_test.exs
+++ b/test/emerge_skia/build_config_test.exs
@@ -117,6 +117,7 @@ defmodule EmergeSkia.BuildConfigTest do
     assert {url, headers} = BuildConfig.precompiled_tar_gz_url("demo.tar.gz", env)
     assert url =~ "/releases/download/v#{Mix.Project.config()[:version]}/demo.tar.gz"
     assert {"Authorization", "Bearer secret-token"} in headers
+    assert {"User-Agent", "emerge-skia-precompiled"} in headers
   end
 
   test "precompiled_tar_gz_url falls back to plain release urls without a token" do


### PR DESCRIPTION
Use plain GitHub release URLs during Hex publishing for the public repo and add a User-Agent to authenticated fallback requests so GitHub API downloads stay valid when a token is used.