### PR TITLE
fix hex publish defaults

### DIFF
--- a/.github/workflows/private_hex_release.yml
+++ b/.github/workflows/private_hex_release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: main
       organization:
-        description: Hex organization to publish to (optional; falls back to HEX_ORGANIZATION variable)
+        description: Hex organization to publish to (optional; leave blank for the public Hex repo)
         required: false
         default: ""
   workflow_run:
@@ -45,8 +45,6 @@ jobs:
         run: |
           if [ -n "${{ inputs.organization }}" ]; then
             echo "HEX_ORGANIZATION=${{ inputs.organization }}" >> "$GITHUB_ENV"
-          elif [ -n "${{ vars.HEX_ORGANIZATION }}" ]; then
-            echo "HEX_ORGANIZATION=${{ vars.HEX_ORGANIZATION }}" >> "$GITHUB_ENV"
           fi
 
       - name: Set up Elixir and OTP

--- a/lib/emerge_skia/build_config.ex
+++ b/lib/emerge_skia/build_config.ex
@@ -289,8 +289,42 @@ defmodule EmergeSkia.BuildConfig do
   end
 
   defp default_precompiled_target_resolver(targets, nif_versions) do
-    RustlerPrecompiled.target(%{}, targets, nif_versions)
+    RustlerPrecompiled.target(
+      %{
+        os_type: :os.type(),
+        target_system: current_target_system(),
+        word_size: :erlang.system_info(:wordsize),
+        nif_version: current_compatible_nif_version(nif_versions)
+      },
+      targets,
+      nif_versions
+    )
   end
+
+  defp current_compatible_nif_version(nif_versions) do
+    current_nif_version = :erlang.system_info(:nif_version) |> List.to_string()
+
+    case RustlerPrecompiled.find_compatible_nif_version(current_nif_version, nif_versions) do
+      {:ok, version} -> version
+      :error -> current_nif_version
+    end
+  end
+
+  defp current_target_system do
+    :erlang.system_info(:system_architecture)
+    |> List.to_string()
+    |> String.split("-")
+    |> system_arch_parts_to_map()
+    |> RustlerPrecompiled.maybe_override_with_env_vars()
+  end
+
+  defp system_arch_parts_to_map([arch, vendor, os, abi]),
+    do: %{arch: arch, vendor: vendor, os: os, abi: abi}
+
+  defp system_arch_parts_to_map([arch, vendor, os]),
+    do: %{arch: arch, vendor: vendor, os: os}
+
+  defp system_arch_parts_to_map(_parts), do: %{}
 
   defp force_build_requested?(env) do
     Map.get(env, @force_precompiled_build_env_key) in ["1", "true"]

--- a/test/emerge_skia/build_config_test.exs
+++ b/test/emerge_skia/build_config_test.exs
@@ -143,6 +143,16 @@ defmodule EmergeSkia.BuildConfigTest do
            )
   end
 
+  test "force_precompiled_build? resolves the current target without crashing" do
+    assert is_boolean(
+             BuildConfig.force_precompiled_build?(
+               checksum_path: __ENV__.file,
+               compiled_backends: [:wayland],
+               env: %{}
+             )
+           )
+  end
+
   test "force_precompiled_build? forces builds when backend profile is unsupported" do
     assert BuildConfig.force_precompiled_build?(
              checksum_path: __ENV__.file,


### PR DESCRIPTION
Resolve the current precompiled target without relying on an empty RustlerPrecompiled config and only publish to a Hex organization when one is explicitly requested.